### PR TITLE
Clarify delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ See the [Bamboo.Email] and [Bamboo.Formatter docs] for more info and examples.
 
 ## Using Phoenix Views and Layouts
 
-Phoenix is not required to use Bamboo. However, if you do use Phoenix, you can use Phoenix views and layouts with Bamboo. See [Bamboo.Phoenix](https://hexdocs.pm/bamboo/Bamboo.Phoenix.html)
+Phoenix is not required to use Bamboo. However, if you do use Phoenix, you can
+use Phoenix views and layouts with Bamboo. See
+[Bamboo.Phoenix](https://hexdocs.pm/bamboo/Bamboo.Phoenix.html)
 
 ## Previewing Sent Emails
 
@@ -197,11 +199,14 @@ See [Bamboo.EmailPreviewPlug](https://hexdocs.pm/bamboo/Bamboo.EmailPreviewPlug.
 
 ## Mandrill Specific Functionality (tags, merge vars, etc.)
 
-Mandrill offers extra features on top of regular SMTP email like tagging, merge vars, and scheduling emails to send in the future. See [Bamboo.MandrillHelper](https://hexdocs.pm/bamboo/Bamboo.MandrillHelper.html).
+Mandrill offers extra features on top of regular SMTP email like tagging, merge
+vars, and scheduling emails to send in the future. See
+[Bamboo.MandrillHelper](https://hexdocs.pm/bamboo/Bamboo.MandrillHelper.html).
 
 ## Testing
 
-You can use the Bamboo.TestAdapter along with [Bamboo.Test] to make testing your emails a piece of cake.
+You can use the Bamboo.TestAdapter along with [Bamboo.Test] to make testing your
+emails straightforward.
 
 ```elixir
 # Using the mailer from the Getting Started section
@@ -235,7 +240,7 @@ See documentation for [Bamboo.Test] for more examples, and remember to use
 Bamboo.TestAdapter.
 
 [Bamboo.Test]: https://hexdocs.pm/bamboo/Bamboo.Test.html
-  
+
 ## About thoughtbot
 
 ![thoughtbot](https://thoughtbot.com/logo.png)

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -2,8 +2,14 @@ defmodule Bamboo.Mailer do
   @moduledoc """
   Sets up mailers that make it easy to configure and swap adapters.
 
-  Adds `deliver/1` and `deliver_later/1` functions to the mailer module it is used by.
-  Bamboo ships with `Bamboo.MandrillAdapter`, `Bamboo.LocalAdapter` and `Bamboo.TestAdapter`.
+  Adds `deliver_now/1` and `deliver_later/1` functions to the mailer module it is used by.
+
+  ## Bamboo ships with the following adapters
+
+  * `Bamboo.MandrillAdapter`
+  * `Bamboo.LocalAdapter`
+  * `Bamboo.TestAdapter`
+  * or create your own with `Bamboo.Adapter`
 
   ## Example
 
@@ -14,7 +20,7 @@ defmodule Bamboo.Mailer do
 
       # Somewhere in your application. Maybe lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
-        # Adds deliver/1 and deliver_later/1
+        # Adds deliver_now/1 and deliver_later/1
         use Bamboo.Mailer, otp_app: :my_app
       end
 
@@ -45,8 +51,13 @@ defmodule Bamboo.Mailer do
         end
       end
   """
-  require Logger
 
+  @cannot_call_directly_error """
+  cannot call Bamboo.Mailer directly. Instead implement your own Mailer module
+  with: use Bamboo.Mailer, otp_app: :my_app
+  """
+
+  require Logger
   alias Bamboo.Formatter
 
   defmacro __using__(opts) do
@@ -72,6 +83,29 @@ defmodule Bamboo.Mailer do
         """
       end
     end
+  end
+
+  @doc """
+  Deliver an email right away
+
+  Call your mailer with `deliver_now/1` to send an email right away. Call
+  `deliver_later/1` if you want to send in the background to speed things up.
+  """
+  def deliver_now(_email) do
+    raise @cannot_call_directly_error
+  end
+
+  @doc """
+  Deliver an email in the background
+
+  Call your mailer with `deliver_later/1` to send an email using the configured
+  `deliver_later_strategy`. If no `deliver_later_strategy` is set,
+  `Bamboo.TaskSupervisorStrategy` will be used. See
+  `Bamboo.DeliverLaterStrategy` to learn how to change how emails are delivered
+  with `deliver_later/1`.
+  """
+  def deliver_later(_email) do
+    raise @cannot_call_directly_error
   end
 
   @doc false

--- a/lib/bamboo/strategies/deliver_later_strategy.ex
+++ b/lib/bamboo/strategies/deliver_later_strategy.ex
@@ -1,12 +1,15 @@
 defmodule Bamboo.DeliverLaterStrategy do
   @moduledoc """
-  Behaviour for creating strategies for delivering emails with deliver_later
+  Behaviour for delivering emails with `Bamboo.Mailer.deliver_later/1`
 
   Use this behaviour to create strategies for delivering later. You could make a
   strategy using a GenServer, a background job library or whatever else you
-  decide. Bamboo ships with two strategies:
-  `Bamboo.TaskSupervisorStrategy` and
-  `Bamboo.ImmediateDeliveryStrategy`.
+  decide.
+
+  ## Bamboo ships with two strategies:
+
+  * `Bamboo.TaskSupervisorStrategy`
+  * `Bamboo.ImmediateDeliveryStrategy`
 
   ## Example of setting custom strategies
 
@@ -14,7 +17,7 @@ defmodule Bamboo.DeliverLaterStrategy do
         adapter: Bamboo.MandrillAdapter, # or whatever adapter you want
         deliver_later_strategy: MyCustomStrategy
 
-  ## Example of delivering later using Task.async
+  ## Example of creating a custom strategy for delivering later using Task.async
 
       defmodule Bamboo.TaskAsyncStrategy do
         @behaviour Bamboo.DeliverLaterStrategy

--- a/lib/bamboo/strategies/immediate_delivery_strategy.ex
+++ b/lib/bamboo/strategies/immediate_delivery_strategy.ex
@@ -7,6 +7,7 @@ defmodule Bamboo.ImmediateDeliveryStrategy do
 
   @behaviour Bamboo.DeliverLaterStrategy
 
+  @doc false
   def deliver_later(adapter, email, config) do
     adapter.deliver(email, config)
   end

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -5,10 +5,10 @@ defmodule Bamboo.TaskSupervisorStrategy do
   @moduledoc """
   Default strategy. Sends an email in the background using Task.Supervisor
 
-  This is the default strategy because it is the simplest to get started with.
-  This strategy uses a Task.Supervisor to monitor the delivery. Deliveries that
-  fail will raise, but will not be retried, and will not bring down the calling
-  process.
+  This is the default strategy when calling `deliver_later` because it is the
+  simplest to get started with. This strategy uses a Task.Supervisor to monitor
+  the delivery. Deliveries that fail will raise, but will not be retried, and
+  will not bring down the calling process.
 
   To use this strategy, the `Bamboo.TaskSupervisor` must be added to your
   supervisor. See the docs for `child_spec/0` or check out the installation

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bamboo.Mixfile do
 
   def project do
     [app: :bamboo,
-     version: "0.4.0",
+     version: "0.4.1",
      elixir: "~> 1.2",
      source_url: @project_url,
      homepage_url: @project_url,

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -184,6 +184,18 @@ defmodule Bamboo.MailerTest do
     end
   end
 
+  test "raises an error if deliver_now or deliver_later is called directly" do
+    email = new_email(from: %{foo: :bar})
+
+    assert_raise RuntimeError, ~r/cannot call Bamboo.Mailer/, fn ->
+      Bamboo.Mailer.deliver_now(email)
+    end
+
+    assert_raise RuntimeError, ~r/cannot call Bamboo.Mailer/, fn ->
+      Bamboo.Mailer.deliver_later(email)
+    end
+  end
+
   defp new_email(attrs \\ []) do
     attrs = Keyword.merge([from: "foo@bar.com", to: "foo@bar.com"], attrs)
     Email.new_email(attrs)


### PR DESCRIPTION
If someone accidentally calls the Bamboo.Mailer directly, they get a
helpful message. This also allows us to add some docs to the deliver_now
and deliver_later functions.

Also bumps the version so I can update some errors in the docs. 