### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ config :my_app, MyApp.Mailer,
   adapter: Bamboo.LocalAdapter
 ```
 
-[bamboo]: http://github.com/paulcsmith/bamboo
+[bamboo]: https://github.com/thoughtbot/bamboo
 [create your own adapter]: https://hexdocs.pm/bamboo/Bamboo.Adapter.html
 
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
http://github.com/paulcsmith/bamboo | https://github.com/thoughtbot/bamboo 
