### PR TITLE
Show the email in the list instead of the selected

### DIFF
--- a/lib/bamboo/plug/index.html.eex
+++ b/lib/bamboo/plug/index.html.eex
@@ -140,8 +140,8 @@
             href="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(email)}" %>">
             <span class="email-summary-subject truncate"><%= email.subject %></span>
             <span class="email-summary-recipients truncate">
-              <%= Bamboo.Email.get_address(@selected_email.from) %>
-              to <%= Bamboo.EmailPreviewPlug.Helper.email_addresses(@selected_email) %>
+              <%= Bamboo.Email.get_address(email.from) %>
+              to <%= Bamboo.EmailPreviewPlug.Helper.email_addresses(email) %>
             </span>
             <span class="email-summary-body-excerpt"><%= email.text_body %></span>
           </a>

--- a/test/lib/bamboo/plug/email_preview_plug_test.exs
+++ b/test/lib/bamboo/plug/email_preview_plug_test.exs
@@ -32,6 +32,7 @@ defmodule Bamboo.EmailPreviewTest do
     for email <- emails do
       assert Floki.raw_html(sidebar(conn)) =~ ~s(href="/sent_emails/foo/#{SentEmail.get_id(email)}")
       assert Floki.text(sidebar(conn)) =~ email.subject
+      assert Floki.text(sidebar(conn)) =~ Bamboo.Email.get_address(email.from)
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,7 @@ defmodule Bamboo.Factory do
 
   def factory(:email) do
     %Bamboo.Email{
-      from: "from@gmail.com",
+      from: sequence(:email, &"from-#{&1}@gmail.com"),
       subject: sequence("Email subject")
     }
   end


### PR DESCRIPTION
This fixes a bug where the sidebar only showed the `from` address
of the currently selected email.

This also changes the factory to use a sequence so that the tests that require
multiple emails will create unique data.