### PR TITLE
Start TaskSupervisor by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,6 @@ config :my_app, MyApp.Mailer,
   end
   ```
 
-3. Add the the `Bamboo.TaskSupervisor` as a child to your supervisor. This is necessary for `deliver_later` to work.
-
-  ```elixir
-  # Usually in lib/my_app_name.ex
-  children = [
-    # This is where you add the supervisor that handles deliver_later calls
-    Bamboo.TaskSupervisorStrategy.child_spec
-  ]
-  ```
-
 ## Getting Started
 
 Bamboo breaks email creation and email sending into two separate modules. This

--- a/lib/bamboo.ex
+++ b/lib/bamboo.ex
@@ -34,7 +34,9 @@ defmodule Bamboo do
 
     children = [
       worker(Bamboo.SentEmail, []),
+      supervisor(Task.Supervisor, [[name: Bamboo.TaskSupervisorStrategy.supervisor_name]])
     ]
+
     opts = [strategy: :one_for_one, name: Bamboo.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -1,18 +1,13 @@
 defmodule Bamboo.TaskSupervisorStrategy do
   @behaviour Bamboo.DeliverLaterStrategy
-  @supervisor_name Bamboo.TaskSupervior
 
   @moduledoc """
   Default strategy. Sends an email in the background using Task.Supervisor
 
   This is the default strategy when calling `deliver_later` because it is the
-  simplest to get started with. This strategy uses a Task.Supervisor to monitor
+  simplest to get started with. This strategy uses a `Task.Supervisor` to monitor
   the delivery. Deliveries that fail will raise, but will not be retried, and
   will not bring down the calling process.
-
-  To use this strategy, the `Bamboo.TaskSupervisor` must be added to your
-  supervisor. See the docs for `child_spec/0` or check out the installation
-  section of the README.
 
   ## Why use it?
 
@@ -25,26 +20,21 @@ defmodule Bamboo.TaskSupervisorStrategy do
 
   @doc false
   def deliver_later(adapter, email, config) do
-    Task.Supervisor.start_child @supervisor_name, fn ->
+    Task.Supervisor.start_child supervisor_name, fn ->
       adapter.deliver(email, config)
     end
   end
 
-  @doc """
-  Child spec for use in your supervisor
+  def supervisor_name do
+    Bamboo.TaskSupervisor
+  end
 
-  ## Example
-
-      # Usually in lib/my_app_name.ex
-      children = [
-        # Add the supervisor that handles deliver_later calls
-        Bamboo.TaskSupervisorStrategy.child_spec
-      ]
-  """
+  @doc false
   def child_spec do
-    Supervisor.Spec.supervisor(
-      Task.Supervisor,
-      [[name: @supervisor_name]]
-    )
+    raise """
+    the TaskSupervisorStrategy is now started automatically by the :bamboo application.
+
+    You can safely remove Bamboo.TaskSupervisorStrategy.child_spec
+    """
   end
 end

--- a/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
+++ b/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
@@ -21,12 +21,9 @@ defmodule Bamboo.TaskSupervisorStrategyTest do
     assert_receive :delivered
   end
 
-  test "child_spec" do
-    spec = Bamboo.TaskSupervisorStrategy.child_spec
-
-    assert spec == Supervisor.Spec.supervisor(
-      Task.Supervisor,
-      [[name: Bamboo.TaskSupervior]]
-    )
+  test "child_spec raises error about removal" do
+    assert_raise RuntimeError, ~r/remove Bamboo.TaskSupervisorStrategy.child_spec/, fn ->
+      Bamboo.TaskSupervisorStrategy.child_spec
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,5 @@
 ExUnit.start()
 
-Supervisor.start_child(
-  Bamboo.Supervisor,
-  Bamboo.TaskSupervisorStrategy.child_spec
-)
-
 Application.ensure_all_started(:phoenix)
 Application.ensure_all_started(:cowboy)
 Application.ensure_all_started(:ex_machina)


### PR DESCRIPTION
The reason for this is that if two applications start bamboo and both of
them added Bamboo.TaskSupervisorStrategy.child_spec to their children,
then there would be an error because it was started twice.

This circumvents that by starting it just once when Bamboo starts. This
also simplifies the installation instructions.

Closes #131 