### PR TITLE
Add an SMTP adapter

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -82,6 +82,14 @@ defmodule Bamboo.SMTPAdapter do
     add_smtp_body_line(body, :cc, format_email(recipients, :cc))
   end
 
+  defp add_custom_header(body, {key, value}) do
+    body <> key <> ": " <> value <> "\r\n"
+  end
+
+  defp add_custom_headers(body, %Bamboo.Email{headers: headers}) do
+    Enum.reduce(headers, body, &add_custom_header(&2, &1))
+  end
+
   defp add_ending_header(body) do
     body <> "\r\n"
   end
@@ -157,6 +165,7 @@ defmodule Bamboo.SMTPAdapter do
     |> add_bcc(email)
     |> add_cc(email)
     |> add_to(email)
+    |> add_custom_headers(email)
     |> add_mime_header
     |> add_multipart_header(multi_part_delimiter)
     |> add_ending_header

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -1,9 +1,9 @@
 defmodule Bamboo.SMTPAdapter do
   @moduledoc """
-  Sends email using SMTP protocol.
+  Sends email using SMTP.
 
-  Use this adapter to send emails through SMTP protocol. Requires that some
-  settings are set in the config. See the example section below.
+  Use this adapter to send emails through SMTP. This adapter requires
+  that some settings are set in the config. See the example section below.
 
   ## Example config
 

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -1,0 +1,221 @@
+defmodule Bamboo.SMTPAdapter do
+  @moduledoc """
+  Sends email using SMTP protocol.
+
+  Use this adapter to send emails through SMTP protocol. Requires that some
+  settings are set in the config. See the example section below.
+
+  ## Example config
+
+      # In config/config.exs, or config.prod.exs, etc.
+      config :my_app, MyApp.Mailer,
+        adapter: Bamboo.SMTPAdapter,
+        server: "smtp.domain",
+        port: 1025,
+        username: "your.name@your.domain"
+        password: "pa55word",
+        tls: :if_available, # can be `:always` or `:never`
+        ssl: :false, # can be `:true`
+        retries: 1
+
+      # Define a Mailer. Maybe in lib/my_app/mailer.ex
+      defmodule MyApp.Mailer do
+        use Bamboo.Mailer, otp_app: :my_app
+      end
+  """
+
+  @behaviour Bamboo.Adapter
+
+  require Logger
+
+  @required_configuration [:server, :port, :username, :password]
+  @default_configuration [tls: :if_available, ssl: :false, retries: 1, transport: :smtp]
+
+  defmodule SMTPError do
+    defexception [:message]
+
+    def exception({:error, reason, detail}) do
+      message = """
+      There was a problem sending the email through SMTP.
+
+      The error is #{inspect reason}
+
+      More detail below:
+
+      #{inspect detail}
+      """
+
+      %SMTPError{message: message}
+    end
+  end
+
+  def deliver(email, _config) do
+    email
+    |> to_mailer_message
+    |> Mailer.send
+    |> check_smtp_response
+  end
+
+  @doc false
+  def handle_config(config) do
+    config
+    |> check_required_configuration
+    |> put_default_configuration
+    |> define_mailer_environment
+  end
+
+  defp add_bcc(%Mailer.Email.Multipart{} = email, %Bamboo.Email{bcc: bcc})
+  when bcc == nil or bcc == [] do
+    email
+  end
+  defp add_bcc(%Mailer.Email.Multipart{} = email, %Bamboo.Email{} = _from_email) do
+    not_yet_supported
+
+    email
+  end
+
+  defp add_cc(%Mailer.Email.Multipart{} = email, %Bamboo.Email{cc: cc})
+  when cc == nil or cc == [] do
+    email
+  end
+  defp add_cc(%Mailer.Email.Multipart{} = email, %Bamboo.Email{} = _from_email) do
+    not_yet_supported
+
+    email
+  end
+
+  defp add_date(%Mailer.Email.Multipart{} = email, %Bamboo.Email{} = _from_email) do
+    Mailer.Email.Multipart.add_date(email, Mailer.Util.localtime_to_str)
+  end
+
+  defp add_from(%Mailer.Email.Multipart{} = email, %Bamboo.Email{from: from}) do
+    sender =
+      from
+      |> Bamboo.Formatter.format_email_address(:from)
+      |> format_email_address_as_string
+
+    Mailer.Email.Multipart.add_from(email, sender)
+  end
+
+  defp add_html_body(%Mailer.Email.Multipart{} = email, %Bamboo.Email{html_body: html_body}) do
+    Mailer.Email.Multipart.add_html_body(email, html_body)
+  end
+
+  defp add_message_id(%Mailer.Email.Multipart{} = email, %Bamboo.Email{from: from}) do
+    message_id =
+      from
+      |> Bamboo.Formatter.format_email_address(:from)
+      |> format_email_address_as_string
+      |> Mailer.Message.Id.create
+
+    Mailer.Email.Multipart.add_message_id(email, message_id)
+  end
+
+  defp add_subject(%Mailer.Email.Multipart{} = email, %Bamboo.Email{subject: subject}) do
+    Mailer.Email.Multipart.add_subject(email, subject)
+  end
+
+  defp add_text_body(%Mailer.Email.Multipart{} = email, %Bamboo.Email{text_body: text_body}) do
+    Mailer.Email.Multipart.add_text_body(email, text_body)
+  end
+
+  defp add_to(%Mailer.Email.Multipart{} = email, %Bamboo.Email{to: to}) do
+    to
+    |> Bamboo.Formatter.format_email_address(:to)
+    |> format_email_address_as_string
+    |> Enum.reduce(email, &Mailer.Email.Multipart.add_to(&2, &1))
+  end
+
+  defp aggregate_errors(config, key, errors) do
+    config
+    |> Map.fetch(key)
+    |> build_error(key, errors)
+  end
+
+  defp build_error({:ok, _value}, _key, errors), do: errors
+  defp build_error(:error, key, errors) do
+    Dict.put_new(errors, key, "Key #{key} is required for SMTP Adapter")
+  end
+
+  defp check_required_configuration(config) do
+    @required_configuration
+    |> Enum.reduce([], &aggregate_errors(config, &1, &2))
+    |> raise_on_missing_setting(config)
+  end
+
+  defp check_smtp_response({:error, _reason, _detail} = error), do: raise(SMTPError, error)
+  defp check_smtp_response(_success), do: :ok
+
+  defp define_mailer_environment(config) do
+    mailer_config =
+      config
+      |> Enum.into([])
+      |> Enum.filter(&part_of_mailer_configuration?/1)
+
+    Application.put_env(:mailer, :smtp_client, mailer_config)
+
+    config
+  end
+
+  defp format_email_address_as_string({nil, email}), do: email
+  defp format_email_address_as_string({_name, email}), do: email
+  defp format_email_address_as_string(emails) when is_list(emails) do
+    Enum.map(emails, &format_email_address_as_string/1)
+  end
+
+  defp not_yet_supported, do: Logger.warn "BCC feature is not supported by SMTP adapter"
+
+  defp part_of_mailer_configuration?({key, _value}) when key in @required_configuration, do: true
+  defp part_of_mailer_configuration?({key, _value}) do
+    @default_configuration
+    |> Enum.map(fn ({default_key, _default_value}) -> default_key end)
+    |> Enum.any?(&(&1 == key))
+  end
+
+  defp put_default_configuration(config) do
+    @default_configuration
+    |> Enum.reduce(config, &put_default_configuration(&2, &1))
+  end
+
+  defp put_default_configuration(config, default = {key, _default_value}) do
+    config
+    |> Dict.fetch(key)
+    |> apply_default_configuration(default, config)
+  end
+
+  defp apply_default_configuration({:ok, _value}, _default, config), do: config
+  defp apply_default_configuration(:error, {key, default_value}, config) do
+    Dict.put_new(config, key, default_value)
+  end
+
+  defp raise_on_missing_setting([], config), do: config
+  defp raise_on_missing_setting(errors, config) do
+    formatted_errors =
+      errors
+      |> Enum.map(&("* #{&1}"))
+      |> Enum.join("\n")
+
+    raise ArgumentError, """
+    The following settings have not been found in your settings:
+
+    #{formatted_errors}
+
+    They are required to make the SMTP adapter work. Here you configuration:
+
+    #{inspect config}
+    """
+  end
+
+  defp to_mailer_message(%Bamboo.Email{} = email) do
+    Mailer.Email.Multipart.create
+    |> add_from(email)
+    |> add_to(email)
+    |> add_bcc(email)
+    |> add_cc(email)
+    |> add_subject(email)
+    |> add_message_id(email)
+    |> add_date(email)
+    |> add_html_body(email)
+    |> add_text_body(email)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Bamboo.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:logger, :httpoison, :poison],
+      applications: [:logger, :httpoison, :mailer, :poison],
       mod: {Bamboo, []}
     ]
   end
@@ -52,6 +52,7 @@ defmodule Bamboo.Mixfile do
       {:plug, "~> 1.0"},
       {:ex_machina, "~> 1.0.0-beta.0", github: "thoughtbot/ex_machina", only: [:test]},
       {:cowboy, "~> 1.0", only: [:test, :dev]},
+      {:mailer, "~> 1.0"},
       {:phoenix, "~> 1.1", only: :test},
       {:phoenix_html, "~> 2.2", only: :test},
       {:excoveralls, "~> 0.4", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Bamboo.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:logger, :httpoison, :mailer, :poison],
+      applications: [:logger, :gen_smtp, :httpoison, :poison],
       mod: {Bamboo, []}
     ]
   end
@@ -52,7 +52,7 @@ defmodule Bamboo.Mixfile do
       {:plug, "~> 1.0"},
       {:ex_machina, "~> 1.0.0-beta.0", github: "thoughtbot/ex_machina", only: [:test]},
       {:cowboy, "~> 1.0", only: [:test, :dev]},
-      {:mailer, "~> 1.0"},
+      {:gen_smtp, "~> 0.9.0"},
       {:phoenix, "~> 1.1", only: :test},
       {:phoenix_html, "~> 2.2", only: :test},
       {:excoveralls, "~> 0.4", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"certifi": {:hex, :certifi, "0.3.0"},
+  "combine": {:hex, :combine, "0.7.0"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "earmark": {:hex, :earmark, "0.2.1"},
@@ -7,10 +8,13 @@
   "excoveralls": {:hex, :excoveralls, "0.5.1"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "floki": {:hex, :floki, "0.8.0"},
+  "gen_smtp": {:hex, :gen_smtp, "0.9.0"},
+  "gettext": {:hex, :gettext, "0.11.0"},
   "hackney": {:hex, :hackney, "1.4.8"},
   "httpoison": {:hex, :httpoison, "0.8.1"},
   "idna": {:hex, :idna, "1.0.3"},
   "jsx": {:hex, :jsx, "2.6.2"},
+  "mailer": {:hex, :mailer, "1.0.1"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mochiweb_html": {:hex, :mochiweb_html, "2.13.0"},
   "phoenix": {:hex, :phoenix, "1.1.4"},
@@ -18,4 +22,6 @@
   "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "2.1.0"},
   "ranch": {:hex, :ranch, "1.2.1"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "timex": {:hex, :timex, "2.1.4"},
+  "tzdata": {:hex, :tzdata, "0.5.7"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{"certifi": {:hex, :certifi, "0.3.0"},
-  "combine": {:hex, :combine, "0.7.0"},
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "earmark": {:hex, :earmark, "0.2.1"},
@@ -9,12 +8,10 @@
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "floki": {:hex, :floki, "0.8.0"},
   "gen_smtp": {:hex, :gen_smtp, "0.9.0"},
-  "gettext": {:hex, :gettext, "0.11.0"},
   "hackney": {:hex, :hackney, "1.4.8"},
   "httpoison": {:hex, :httpoison, "0.8.1"},
   "idna": {:hex, :idna, "1.0.3"},
   "jsx": {:hex, :jsx, "2.6.2"},
-  "mailer": {:hex, :mailer, "1.0.1"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mochiweb_html": {:hex, :mochiweb_html, "2.13.0"},
   "phoenix": {:hex, :phoenix, "1.1.4"},
@@ -22,6 +19,4 @@
   "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "2.1.0"},
   "ranch": {:hex, :ranch, "1.2.1"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "2.1.4"},
-  "tzdata": {:hex, :tzdata, "0.5.7"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -1,0 +1,75 @@
+defmodule Bamboo.SMTPAdapterTest do
+  use ExUnit.Case
+  alias Bamboo.SMTPAdapter
+
+  @configuration %{
+    adapter: SMTPAdapter,
+    server: "smtp.domain",
+    port: 1025,
+    username: "your.name@your.domain",
+    password: "pa55word"
+  }
+
+  test "raises if the server is nil" do
+    assert_raise ArgumentError, ~r/Key server is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{server: nil}))
+    end
+  end
+
+  test "raises if the port is nil" do
+    assert_raise ArgumentError, ~r/Key port is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{port: nil}))
+    end
+  end
+
+  test "raises if the username is nil" do
+    assert_raise ArgumentError, ~r/Key username is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{username: nil}))
+    end
+  end
+
+  test "raises if the password is nil" do
+    assert_raise ArgumentError, ~r/Key password is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{password: nil}))
+    end
+  end
+
+  test "sets default tls key if not present" do
+    %{tls: tls} = SMTPAdapter.handle_config(configuration)
+
+    assert :if_available == tls
+  end
+
+  test "doesn't set a default tls key if present" do
+    %{tls: tls} = SMTPAdapter.handle_config(configuration(%{tls: :always}))
+
+    assert :always == tls
+  end
+
+  test "sets default ssl key if not present" do
+    %{ssl: ssl} = SMTPAdapter.handle_config(configuration)
+
+    refute ssl
+  end
+
+  test "doesn't set a default ssl key if present" do
+    %{ssl: ssl} = SMTPAdapter.handle_config(configuration(%{ssl: true}))
+
+    assert ssl
+  end
+
+  test "sets default retries key if not present" do
+    %{retries: retries} = SMTPAdapter.handle_config(configuration)
+
+    assert retries == 1
+  end
+
+  test "doesn't set a default retries key if present" do
+    %{retries: retries} = SMTPAdapter.handle_config(configuration(%{retries: 42}))
+
+    assert retries == 42
+  end
+
+  defp configuration, do: @configuration
+  defp configuration(override), do: Map.merge(configuration, override)
+end

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -1,14 +1,91 @@
 defmodule Bamboo.SMTPAdapterTest do
   use ExUnit.Case
+
+  alias Bamboo.Email
   alias Bamboo.SMTPAdapter
+
+  defmodule FakeGenSMTP do
+    use GenServer
+
+    def start_link do
+      GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    end
+
+    def send_blocking(email, config) do
+      GenServer.call(__MODULE__, {:send_email, {email, config}})
+    end
+
+    def fetch_sent_emails do
+      GenServer.call(__MODULE__, :fetch_emails)
+    end
+
+    def handle_call(:fetch_emails, _from, state) do
+      {:reply, state, state}
+    end
+
+    def handle_call({:send_email, {email, config}}, {pid, _reference}, state) do
+      case check_validity(email, config) do
+        :ok ->
+          {:reply, :ok, [{email, config}|state]}
+        error ->
+          {:reply, error, state}
+      end
+    end
+
+    defp check_validity(email, config) do
+      with :ok <- check_configuration(config),
+           :ok <- check_email(email),
+      do: :ok
+    end
+
+    defp check_configuration(config) do
+      case Keyword.fetch(config, :relay) do
+        {:ok, wrong_domain = "wrong.smtp.domain"} ->
+          {:error, :retries_exceeded, {:network_failure, wrong_domain, {:error, :nxdomain}}}
+        _ ->
+          :ok
+      end
+    end
+
+    defp check_email({from, _to, _raw}) do
+      case from do
+        "<wrong@user.com> Wrong User" ->
+          {:error, :no_more_hosts, {:permanent_failure,
+                                    "an-smtp-adddress", "554 Message rejected: Email address is not verified.\r\n"}}
+        _ ->
+          :ok
+      end
+    end
+  end
 
   @configuration %{
     adapter: SMTPAdapter,
     server: "smtp.domain",
     port: 1025,
     username: "your.name@your.domain",
-    password: "pa55word"
+    password: "pa55word",
+    transport: FakeGenSMTP
   }
+
+  @email [
+    from: {"John Doe", "john@doe.com"},
+    to: [{"Jane Doe", "jane@doe.com"}],
+    cc: [{"Richard Roe", "richard@roe.com"}],
+    bcc: [{"Mary Major", "mary@major.com"},
+          {"Joe Major", "joe@major.com"}],
+    subject: "Hello from Bamboo",
+    html_body: "<h1>Bamboo is awesome!</h1>",
+    text_body: "*Bamboo is awesome!*",
+    headers: %{
+      "Reply-To" => "reply@doe.com"
+    }
+  ]
+
+  setup do
+    FakeGenSMTP.start_link
+
+    :ok
+  end
 
   test "raises if the server is nil" do
     assert_raise ArgumentError, ~r/Key server is required/, fn ->
@@ -70,6 +147,164 @@ defmodule Bamboo.SMTPAdapterTest do
     assert retries == 42
   end
 
-  defp configuration, do: @configuration
-  defp configuration(override), do: Map.merge(configuration, override)
+  test "emails raise an exception when configuration is wrong" do
+    bamboo_email = new_email
+    bamboo_config = configuration(%{server: "wrong.smtp.domain"})
+
+    assert_raise SMTPAdapter.SMTPError, ~r/network_failure/, fn ->
+      SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    end
+  end
+
+  test "emails raise an exception when email can't be sent" do
+    bamboo_email = new_email(from: {"Wrong User", "wrong@user.com"})
+    bamboo_config = configuration
+
+    assert_raise SMTPAdapter.SMTPError, ~r/554 Message rejected/, fn ->
+      SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    end
+  end
+
+  test "emails looks fine when only text body is set" do
+    bamboo_email = new_email(text_body: nil)
+    bamboo_config = configuration
+
+    :ok = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert 1 = length(FakeGenSMTP.fetch_sent_emails)
+
+    [{{from, to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    [multipart_header] =
+      Regex.run(
+        ~r{Content-Type: multipart/alternative; boundary="([^"]+)"\r\n},
+        raw_email,
+        capture: :all_but_first)
+
+    assert format_email_as_string(bamboo_email.from) == from
+    assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc) == to
+
+    assert String.contains?(raw_email, "Subject: #{bamboo_email.subject}\r\n")
+    assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
+    assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
+    assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
+    assert String.contains?(raw_email, "Bcc: #{format_email_as_string(bamboo_email.bcc)}\r\n")
+    assert String.contains?(raw_email, "Reply-To: reply@doe.com\r\n")
+    assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/html;charset=UTF-8\r\n" <>
+                                        "Content-ID: html-body\r\n" <>
+                                        "#{bamboo_email.html_body}\r\n")
+    refute String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/plain;charset=UTF-8\r\n" <>
+                                        "Content-ID: text-body\r\n")
+
+    assert_configuration bamboo_config, gen_smtp_config
+  end
+
+  test "emails looks fine when only HTML body is set" do
+    bamboo_email = new_email(html_body: nil)
+    bamboo_config = configuration
+
+    :ok = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert 1 = length(FakeGenSMTP.fetch_sent_emails)
+
+    [{{from, to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    [multipart_header] =
+      Regex.run(
+        ~r{Content-Type: multipart/alternative; boundary="([^"]+)"\r\n},
+        raw_email,
+        capture: :all_but_first)
+
+    assert format_email_as_string(bamboo_email.from) == from
+    assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc) == to
+
+    assert String.contains?(raw_email, "Subject: #{bamboo_email.subject}\r\n")
+    assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
+    assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
+    assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
+    assert String.contains?(raw_email, "Bcc: #{format_email_as_string(bamboo_email.bcc)}\r\n")
+    assert String.contains?(raw_email, "Reply-To: reply@doe.com\r\n")
+    assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
+    refute String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/html;charset=UTF-8\r\n" <>
+                                        "Content-ID: html-body\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/plain;charset=UTF-8\r\n" <>
+                                        "Content-ID: text-body\r\n" <>
+                                        "#{bamboo_email.text_body}\r\n")
+
+    assert_configuration bamboo_config, gen_smtp_config
+  end
+
+  test "emails looks fine when text and HTML bodys are sets" do
+    bamboo_email = new_email
+    bamboo_config = configuration
+
+    :ok = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert 1 = length(FakeGenSMTP.fetch_sent_emails)
+
+    [{{from, to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    [multipart_header] =
+      Regex.run(
+        ~r{Content-Type: multipart/alternative; boundary="([^"]+)"\r\n},
+        raw_email,
+        capture: :all_but_first)
+
+    assert format_email_as_string(bamboo_email.from) == from
+    assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc) == to
+
+    assert String.contains?(raw_email, "Subject: #{bamboo_email.subject}\r\n")
+    assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
+    assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
+    assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
+    assert String.contains?(raw_email, "Bcc: #{format_email_as_string(bamboo_email.bcc)}\r\n")
+    assert String.contains?(raw_email, "Reply-To: reply@doe.com\r\n")
+    assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/html;charset=UTF-8\r\n" <>
+                                        "Content-ID: html-body\r\n" <>
+                                        "#{bamboo_email.html_body}\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/plain;charset=UTF-8\r\n" <>
+                                        "Content-ID: text-body\r\n" <>
+                                        "#{bamboo_email.text_body}\r\n")
+
+    assert_configuration bamboo_config, gen_smtp_config
+  end
+
+  defp format_email({name, email}), do: "<#{email}> #{name}"
+  defp format_email(emails) when is_list(emails) do
+    emails |> Enum.map(&format_email/1)
+  end
+
+  defp format_email_as_string(emails) when is_list(emails) do
+    format_email(emails) |> Enum.join(", ")
+  end
+  defp format_email_as_string(email) do
+    format_email(email)
+  end
+
+  defp assert_configuration(bamboo_config, gen_smtp_config) do
+    assert bamboo_config[:server] == gen_smtp_config[:relay]
+    assert bamboo_config[:port] == gen_smtp_config[:port]
+    assert bamboo_config[:username] == gen_smtp_config[:username]
+    assert bamboo_config[:password] == gen_smtp_config[:password]
+    assert bamboo_config[:tls] == gen_smtp_config[:tls]
+    assert bamboo_config[:ssl] == gen_smtp_config[:ssl]
+    assert bamboo_config[:retries] == gen_smtp_config[:retries]
+  end
+
+  defp configuration(override \\ %{}), do: Map.merge(@configuration, override)
+
+  defp new_email(override \\ []) do
+    @email
+    |> Keyword.merge(override)
+    |> Email.new_email
+    |> Bamboo.Mailer.normalize_addresses
+  end
 end


### PR DESCRIPTION
The current implementation supports:

* sending emails through SMTP (use `gen_smtp`)
* `tls`, and `ssl` protocols
* `cc` and `bcc`

I'm not quite sure if it meets `bamboo` standards but it works on my application. I just wanted to create the PR early to have feedbacks as soon as possible.

We still need to add, at least:

* [x] tests

Any feedback is welcome 😸 