### PR TITLE
Remove process_name. Add shared mode

### DIFF
--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -25,7 +25,7 @@ defmodule Bamboo.TestAdapter do
   end
 
   defp test_process do
-    Application.get_env(:bamboo, :test_process_name) || self()
+    Application.get_env(:bamboo, :shared_test_process) || self()
   end
 
   def handle_config(config) do

--- a/test/lib/bamboo/multi_process_test.exs
+++ b/test/lib/bamboo/multi_process_test.exs
@@ -1,6 +1,6 @@
 defmodule Bamboo.MultiProcessTest do
   use ExUnit.Case
-  use Bamboo.Test, process_name: :multi_process_test
+  use Bamboo.Test, shared: true
   import Bamboo.Email
 
   Application.put_env(
@@ -23,13 +23,13 @@ defmodule Bamboo.MultiProcessTest do
     assert_delivered_email email
   end
 
-  test "refute_delivered_email with process_name set and with refute_timeout blank, raises an error" do
+  test "refute_delivered_email with shared mode and with refute_timeout blank, raises an error" do
     assert_raise RuntimeError, ~r/set a timeout/, fn ->
       refute_delivered_email new_email(from: "someone")
     end
   end
 
-  test "assert_no_emails_delivered with process_name set and with refute_timeout blank, raises an error" do
+  test "assert_no_emails_delivered with shared mode and with refute_timeout blank, raises an error" do
     assert_raise RuntimeError, ~r/set a timeout/, fn ->
       assert_no_emails_delivered
     end


### PR DESCRIPTION
Closes #130. This makes usage simpler and adds some clarity to what is
going on.