### PR TITLE
improving error message when invalid mailer configuration

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -184,7 +184,7 @@ defmodule Bamboo.Mailer do
   @doc false
   def parse_opts(mailer, opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    config = Application.get_env(otp_app, mailer) |> Enum.into(%{})
+    config = Application.fetch_env!(otp_app, mailer) |> Enum.into(%{})
 
     config.adapter.handle_config(config)
     |> Map.put_new(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)


### PR DESCRIPTION
If we don't configure properly the mailer, there is a compiler error that does not give much information.
See issue: #149
```
= Compilation error on file lib/mailer.ex ==
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:116: Enumerable.reduce/3
    (elixir) lib/enum.ex:1486: Enum.reduce/3
    lib/bamboo/mailer.ex:187: Bamboo.Mailer.parse_opts/2
    lib/mailer.ex:2: (module)
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
    (elixir) lib/kernel/parallel_compiler.ex:100: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/8
```
By doing the change in this pull request we get a better error message:

```
== Compilation error on file lib/mailer.ex ==
** (ArgumentError) application :basic_guardian is not loaded, or the configuration parameter BasicGuardian.Mailer is not set
    (elixir) lib/application.ex:203: Application.fetch_env!/2
    lib/bamboo/mailer.ex:187: Bamboo.Mailer.parse_opts/2
    lib/mailer.ex:2: (module)
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
    (elixir) lib/kernel/parallel_compiler.ex:100: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/8
```
```
```