### PR TITLE
Catch all nil emails

### DIFF
--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -178,7 +178,17 @@ defmodule Bamboo.MailerTest do
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
-      new_email(to: nil, cc: {"foo", nil}, bcc: [{"bar", nil}])
+      new_email(to: {"foo", nil})
+      |> FooMailer.deliver_now
+    end
+
+    assert_raise Bamboo.NilRecipientsError, fn ->
+      new_email(to: [{"foo", nil}])
+      |> FooMailer.deliver_now
+    end
+
+    assert_raise Bamboo.NilRecipientsError, fn ->
+      new_email(to: [nil])
       |> FooMailer.deliver_now
     end
   end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -78,10 +78,12 @@ defmodule Bamboo.MailerTest do
   end
 
   test "deliver_now/1 with no from address" do
-    email = new_email(from: nil)
+    assert_raise Bamboo.EmptyFromAddressError, fn ->
+      FooMailer.deliver_now(new_email(from: nil))
+    end
 
     assert_raise Bamboo.EmptyFromAddressError, fn ->
-      FooMailer.deliver_now(email)
+      FooMailer.deliver_now(new_email(from: {"foo", nil}))
     end
   end
 
@@ -173,6 +175,11 @@ defmodule Bamboo.MailerTest do
   test "raises if all receipients are nil" do
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: nil, cc: nil, bcc: nil) |> FooMailer.deliver_now
+    end
+
+    assert_raise Bamboo.NilRecipientsError, fn ->
+      new_email(to: nil, cc: {"foo", nil}, bcc: [{"bar", nil}])
+      |> FooMailer.deliver_now
     end
   end
 


### PR DESCRIPTION
Fix #146 

@paulcsmith 

I was tempted to swap the order of `validate` and `normailize_addresses`, which would reduce a few lines of code, but then I would have to implement `Bamboo.Formatter` for `nil`, which doesn't really make sense.