### PR TITLE
Strip assigns from the email when testing

### DIFF
--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -21,6 +21,7 @@ defmodule Bamboo.TestAdapter do
 
   @doc false
   def deliver(email, _config) do
+    email = clean_assigns(email)
     send test_process, {:delivered_email, email}
   end
 
@@ -45,5 +46,10 @@ defmodule Bamboo.TestAdapter do
         set it to Bamboo.ImmediateDeliveryStrategy.
         """
     end
+  end
+
+  @doc false
+  def clean_assigns(email) do
+    %{email | assigns: :assigns_removed_for_testing}
   end
 end

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -160,7 +160,7 @@ defmodule Bamboo.Test do
       assert_delivered_email(unsent_email) # Will fail
   """
   def assert_delivered_email(%Bamboo.Email{} = email) do
-    email = Bamboo.Mailer.normalize_addresses(email)
+    email = normalize_for_testing(email)
     do_assert_delivered_email(email)
   end
 
@@ -270,7 +270,7 @@ defmodule Bamboo.Test do
   times 1ms is enough.
   """
   def refute_delivered_email(%Bamboo.Email{} = email) do
-    email = Bamboo.Mailer.normalize_addresses(email)
+    email = normalize_for_testing(email)
 
     receive do
       {:delivered_email, ^email} -> flunk_with_unexpected_matching_email(email)
@@ -308,5 +308,11 @@ defmodule Bamboo.Test do
 
   defp using_shared_mode? do
     !!Application.get_env(:bamboo, :shared_test_process)
+  end
+
+  defp normalize_for_testing(email) do
+    email
+    |> Bamboo.Mailer.normalize_addresses
+    |> Bamboo.TestAdapter.clean_assigns
   end
 end

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -160,15 +160,11 @@ defmodule Bamboo.TestAdapterTest do
     assert_delivered_email sent_email
   end
 
-  # The actual sent email and the email tested may have differences in their assigns
-  # Even if the resulting body is the same
-  test "assertion helpers remove assigns" do
-    test_email = new_email(from: "foo@bar.com", to: "bar@baz.com")
-    sent_email = %{test_email | assigns: %{foo: :bar}}
-    expected_email = %{test_email | assigns: %{foo: :baz}}
+  test "delivered emails have normalized assigns" do
+    email = new_email(from: "foo@bar.com", to: "bar@baz.com", assigns: :anything)
 
-    sent_email |> TestMailer.deliver_now
+    email |> TestMailer.deliver_now
 
-    assert_delivered_email expected_email
+    assert_delivered_email %{email | assigns: :assigns_removed_for_testing}
   end
 end

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -33,6 +33,8 @@ defmodule Bamboo.TestAdapterTest do
 
     email |> TestAdapter.deliver(@config)
 
+    email = TestAdapter.clean_assigns(email)
+
     assert_received {:delivered_email, ^email}
   end
 
@@ -156,5 +158,17 @@ defmodule Bamboo.TestAdapterTest do
     sent_email |> TestMailer.deliver_now
 
     assert_delivered_email sent_email
+  end
+
+  # The actual sent email and the email tested may have differences in their assigns
+  # Even if the resulting body is the same
+  test "assertion helpers remove assigns" do
+    test_email = new_email(from: "foo@bar.com", to: "bar@baz.com")
+    sent_email = %{test_email | assigns: %{foo: :bar}}
+    expected_email = %{test_email | assigns: %{foo: :baz}}
+
+    sent_email |> TestMailer.deliver_now
+
+    assert_delivered_email expected_email
   end
 end


### PR DESCRIPTION
I needed this because I’m passing `conn` into some templates
Implements #154 