### PR TITLE
Add SendGrid template support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Mandrill offers extra features on top of regular SMTP email like tagging, merge
 vars, templates, and scheduling emails to send in the future. See
 [Bamboo.MandrillHelper](https://hexdocs.pm/bamboo/Bamboo.MandrillHelper.html).
 
+## SendGrid Specific Functionality (templates and substitution tags)
+
+SendGrid offers extra features on top of regular SMTP email like transactional
+templates with substitution tags. See
+[Bamboo.SendgridHelper](https://hexdocs.pm/bamboo/Bamboo.SendgridHelper.html).
+
 ## Heroku Configuration
 
 If you are deploying to Heroku, you will need to ensure that your configuration

--- a/lib/bamboo/adapters/sendgrid_adapter.ex
+++ b/lib/bamboo/adapters/sendgrid_adapter.ex
@@ -162,7 +162,9 @@ defmodule Bamboo.SendgridAdapter do
     # to neglect doing so themselves.
     case {email.text_body, email.html_body} do
       {nil, nil} -> put_text_body(body, %Email{email | text_body: " "})
-      _ -> body
+      _ -> raise """
+      cannot set the body and use a SendGrid template at the same time. Please remove the body or SendGrid template
+      """
     end |> Map.put("x-smtpapi", Poison.encode!(fields))
   end
   defp maybe_put_x_smtp_api(body, _), do: body

--- a/lib/bamboo/adapters/sendgrid_adapter.ex
+++ b/lib/bamboo/adapters/sendgrid_adapter.ex
@@ -115,6 +115,7 @@ defmodule Bamboo.SendgridAdapter do
     |> put_subject(email)
     |> put_html_body(email)
     |> put_text_body(email)
+    |> put_x_smtp_api(email)
   end
 
   defp put_from(body, %Email{from: {"", address}}), do: Map.put(body, :from, address)
@@ -154,6 +155,17 @@ defmodule Bamboo.SendgridAdapter do
 
   defp put_text_body(body, %Email{text_body: nil}), do: body
   defp put_text_body(body, %Email{text_body: text_body}), do: Map.put(body, :text, text_body)
+
+  defp put_x_smtp_api(body, %Email{private: %{"x-smtpapi" => fields}} = email) do
+    # SendGrid will error with empty bodies, even while using templates.
+    # Sets a default `text_body` if one is not specified, allowing the consumer
+    # to negelect doing so themselves.
+    case {email.text_body, email.html_body} do
+      {nil, nil} -> put_text_body(body, %Email{email | text_body: " "})
+      _ -> body
+    end |> Map.put("x-smtpapi", Poison.encode!(fields))
+  end
+  defp put_x_smtp_api(body, _), do: body
 
   defp put_addresses(body, field, addresses), do: Map.put(body, field, addresses)
   defp put_names(body, field, names) do

--- a/lib/bamboo/adapters/sendgrid_adapter.ex
+++ b/lib/bamboo/adapters/sendgrid_adapter.ex
@@ -115,7 +115,7 @@ defmodule Bamboo.SendgridAdapter do
     |> put_subject(email)
     |> put_html_body(email)
     |> put_text_body(email)
-    |> put_x_smtp_api(email)
+    |> maybe_put_x_smtp_api(email)
   end
 
   defp put_from(body, %Email{from: {"", address}}), do: Map.put(body, :from, address)
@@ -156,16 +156,16 @@ defmodule Bamboo.SendgridAdapter do
   defp put_text_body(body, %Email{text_body: nil}), do: body
   defp put_text_body(body, %Email{text_body: text_body}), do: Map.put(body, :text, text_body)
 
-  defp put_x_smtp_api(body, %Email{private: %{"x-smtpapi" => fields}} = email) do
+  defp maybe_put_x_smtp_api(body, %Email{private: %{"x-smtpapi" => fields}} = email) do
     # SendGrid will error with empty bodies, even while using templates.
     # Sets a default `text_body` if one is not specified, allowing the consumer
-    # to negelect doing so themselves.
+    # to neglect doing so themselves.
     case {email.text_body, email.html_body} do
       {nil, nil} -> put_text_body(body, %Email{email | text_body: " "})
       _ -> body
     end |> Map.put("x-smtpapi", Poison.encode!(fields))
   end
-  defp put_x_smtp_api(body, _), do: body
+  defp maybe_put_x_smtp_api(body, _), do: body
 
   defp put_addresses(body, field, addresses), do: Map.put(body, field, addresses)
   defp put_names(body, field, names) do

--- a/lib/bamboo/adapters/sendgrid_helper.ex
+++ b/lib/bamboo/adapters/sendgrid_helper.ex
@@ -1,0 +1,77 @@
+defmodule Bamboo.SendgridHelper do
+  @moduledoc """
+  Functions for using features specific to Sendgrid template substitution tags.
+
+  Only one template can be specified, but multiple tags can be added to the
+  email. Ordering of the function calls do not make a difference.
+
+  ## Example
+
+      email
+      |> with_template("80509523-83de-42b6-a2bf-54b7513bd2aa")
+      |> substitute("%name%", "Jon Snow")
+      |> substitute("%location%", "Westeros")
+  """
+
+  alias Bamboo.Email
+
+  @id_size 36
+
+  @doc """
+  Specify the template for SendGrid to use for the substitutions
+
+  The `template_id` must be a valid `UUID` as generated for each template by
+  SendGrid. If called multiple times, the last template specified will be used.
+
+  ## Example
+
+      email
+      |> with_template("80509523-83de-42b6-a2bf-54b7513bd2aa")
+  """
+  def with_template(%Email{private: %{"x-smtpapi" => _}} = email, template_id) when byte_size(template_id) == @id_size do
+    fields = email.private["x-smtpapi"]
+             |> Map.merge(%{"filters" => build_template_filter(template_id)})
+
+    email |> Email.put_private("x-smtpapi", fields)
+  end
+
+  def with_template(email, template_id) when byte_size(template_id) == @id_size do
+    email |> Email.put_private("x-smtpapi", %{"filters" => build_template_filter(template_id)})
+  end
+
+  @doc """
+  Add a tag to the list of substitutions in the SendGrid template.
+
+  The tag must be a `String.t` due to SendGrid using special characters to wrap
+  tags in the template.
+
+  ## Example
+
+      email
+      |> substitute("%name%", "Jon Snow")
+  """
+  def substitute(%Email{private: %{"x-smtpapi" => _}} = email, tag, value) when is_binary(tag) do
+    substitutions = Map.get(email.private["x-smtpapi"], "sub", %{})
+      |> Map.merge(%{tag => [value]})
+
+    fields = email.private["x-smtpapi"]
+      |> Map.merge(%{"sub" => substitutions})
+
+    email |> Email.put_private("x-smtpapi", fields)
+  end
+
+  def substitute(email, tag, value) when is_binary(tag) do
+    email |> Email.put_private("x-smtpapi", %{"sub" => %{tag => [value]}})
+  end
+
+  defp build_template_filter(template_id) do
+    %{
+      "templates" => %{
+        "settings" => %{
+          "enabled" => 1,
+          "template_id" => template_id
+        }
+      }
+    }
+  end
+end

--- a/lib/bamboo/adapters/sendgrid_helper.ex
+++ b/lib/bamboo/adapters/sendgrid_helper.ex
@@ -68,7 +68,7 @@ defmodule Bamboo.SendgridHelper do
     %{
       "templates" => %{
         "settings" => %{
-          "enabled" => 1,
+          "enable" => 1,
           "template_id" => template_id
         }
       }

--- a/lib/bamboo/adapters/sendgrid_helper.ex
+++ b/lib/bamboo/adapters/sendgrid_helper.ex
@@ -25,13 +25,12 @@ defmodule Bamboo.SendgridHelper do
       |> with_template("80509523-83de-42b6-a2bf-54b7513bd2aa")
   """
   def with_template(email, template_id) do
-    case byte_size(template_id) == @id_size do
-      false ->
-        raise "expected the template_id parameter to be a UUID 36 characters long, got #{template_id}"
-      true ->
-        xsmtpapi = Map.get(email.private, @field_name, %{})
-        email
-        |> Email.put_private(@field_name, set_template(xsmtpapi, template_id))
+    if byte_size(template_id) == @id_size do
+      xsmtpapi = Map.get(email.private, @field_name, %{})
+      email
+      |> Email.put_private(@field_name, set_template(xsmtpapi, template_id))
+    else
+      raise "expected the template_id parameter to be a UUID 36 characters long, got #{template_id}"
     end
   end
 
@@ -47,13 +46,12 @@ defmodule Bamboo.SendgridHelper do
       |> substitute("%name%", "Jon Snow")
   """
   def substitute(email, tag, value) do
-    case is_binary(tag) do
-      false ->
-        raise "expected the tag parameter to be of type binary, got #{tag}"
-      true ->
-        xsmtpapi = Map.get(email.private, @field_name, %{})
-        email
-        |> Email.put_private(@field_name, add_subsitution(xsmtpapi, tag, value))
+    if is_binary(tag) do
+      xsmtpapi = Map.get(email.private, @field_name, %{})
+      email
+      |> Email.put_private(@field_name, add_subsitution(xsmtpapi, tag, value))
+    else
+      raise "expected the tag parameter to be of type binary, got #{tag}"
     end
   end
 

--- a/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
@@ -128,8 +128,20 @@ defmodule Bamboo.SendgridAdapterTest do
     |> SendgridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["text"]
-    assert params["x-smtpapi"]
+    assert params["text"] == " "
+    assert Poison.decode(params["x-smtpapi"]) == {:ok, %{
+        "sub" => %{
+          "%foo%" => ["bar"]
+        },
+        "filters" => %{
+          "templates" => %{
+            "settings" => %{
+              "enable" => 1,
+              "template_id" => "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
+            }
+          }
+        }
+      }}
   end
 
   test "raises if the response is not a success" do

--- a/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
@@ -116,6 +116,22 @@ defmodule Bamboo.SendgridAdapterTest do
     assert params["bccname"] == ["BCC"]
   end
 
+  test "deliver/2 correctly handles templates" do
+    email = new_email(
+      from: {"From", "from@foo.com"},
+      subject: "My Subject",
+    )
+
+    email
+    |> Bamboo.SendgridHelper.with_template("a4ca8ac9-3294-4eaf-8edc-335935192b8d")
+    |> Bamboo.SendgridHelper.substitute("%foo%", "bar")
+    |> SendgridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["text"]
+    assert params["x-smtpapi"]
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -30,9 +30,9 @@ defmodule Bamboo.SendgridHelperTest do
   end
 
   test "with_template/2 uses the last specified template", %{email: email} do
-    last = "355d0197-ecf5-4268-aa8b-2c0502aec406"
-    email = email |> with_template(@template_id) |> with_template(last)
-    assert email.private["x-smtpapi"]["filters"]["templates"]["settings"]["template_id"] == last
+    last_template_id = "355d0197-ecf5-4268-aa8b-2c0502aec406"
+    email = email |> with_template(@template_id) |> with_template(last_template_id)
+    assert email.private["x-smtpapi"]["filters"]["templates"]["settings"]["template_id"] == last_template_id
   end
 
   test "substitute/3 adds the specified tags", %{email: email} do

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -9,44 +9,44 @@ defmodule Bamboo.SendgridHelperTest do
     {:ok, email: Bamboo.Email.new_email}
   end
 
-  test "(with_template) adds the correct template", %{email: email} do
+  test "with_template/2 adds the correct template", %{email: email} do
     email = email |> with_template(@template_id)
     assert email.private["x-smtpapi"] == %{
-                                            "filters" => %{
-                                              "templates" => %{
-                                                "settings" => %{
-                                                  "enable" => 1,
-                                                  "template_id" => @template_id
-                                                }
-                                              }
-                                            }
-                                          }
+        "filters" => %{
+          "templates" => %{
+            "settings" => %{
+              "enable" => 1,
+              "template_id" => @template_id
+            }
+          }
+        }
+      }
   end
 
-  test "(with_template) raises on non-UUID `template_id`", %{email: email} do
-    assert_raise FunctionClauseError, fn ->
+  test "with_template/2 raises on non-UUID `template_id`", %{email: email} do
+    assert_raise RuntimeError, fn ->
       email |> with_template("not a UUID")
     end
   end
 
-  test "(with_template) uses the last specified template", %{email: email} do
+  test "with_template/2 uses the last specified template", %{email: email} do
     last = "355d0197-ecf5-4268-aa8b-2c0502aec406"
     email = email |> with_template(@template_id) |> with_template(last)
     assert email.private["x-smtpapi"]["filters"]["templates"]["settings"]["template_id"] == last
   end
 
-  test "(substitute) adds the specified tags", %{email: email} do
+  test "substitute/3 adds the specified tags", %{email: email} do
     email = email |> substitute("%name%", "Jon Snow") |> substitute("%location%", "Westeros")
     assert email.private["x-smtpapi"] == %{
-                                            "sub" => %{
-                                              "%name%" => ["Jon Snow"],
-                                              "%location%" => ["Westeros"]
-                                            }
-                                          }
+        "sub" => %{
+          "%name%" => ["Jon Snow"],
+          "%location%" => ["Westeros"]
+        }
+      }
   end
 
-  test "(substitute) raises on non-binary tag", %{email: email} do
-    assert_raise FunctionClauseError, fn ->
+  test "substitute/3 raises on non-binary tag", %{email: email} do
+    assert_raise RuntimeError, fn ->
       email |> substitute(:name, "Jon Snow")
     end
   end
@@ -54,18 +54,18 @@ defmodule Bamboo.SendgridHelperTest do
   test "is structured correctly", %{email: email} do
     email = email |> with_template(@template_id) |> substitute("%name%", "Jon Snow")
     assert email.private["x-smtpapi"] == %{
-                                            "filters" => %{
-                                              "templates" => %{
-                                                "settings" => %{
-                                                  "enable" => 1,
-                                                  "template_id" => @template_id
-                                                }
-                                              }
-                                            },
-                                            "sub" => %{
-                                              "%name%" => ["Jon Snow"]
-                                            }
-                                          }
+        "filters" => %{
+          "templates" => %{
+            "settings" => %{
+              "enable" => 1,
+              "template_id" => @template_id
+            }
+          }
+        },
+        "sub" => %{
+          "%name%" => ["Jon Snow"]
+        }
+      }
   end
 
   test "is non-dependent on function call ordering", %{email: email} do

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -1,0 +1,59 @@
+defmodule Bamboo.SendgridHelperTest do
+  use ExUnit.Case
+
+  import Bamboo.SendgridHelper
+
+  @template_id "80509523-83de-42b6-a2bf-54b7513bd2aa"
+
+  setup do
+    {:ok, email: Bamboo.Email.new_email}
+  end
+
+  test "(with_template) adds the correct template", %{email: email} do
+    email = email |> with_template(@template_id)
+    assert email.private["x-smtpapi"] == %{
+                                            "filters" => %{
+                                              "templates" => %{
+                                                "settings" => %{
+                                                  "enabled" => 1,
+                                                  "template_id" => @template_id
+                                                }
+                                              }
+                                            }
+                                          }
+  end
+
+  test "(with_template) raises on non-UUID `template_id`", %{email: email} do
+    assert_raise FunctionClauseError, fn ->
+      email |> with_template("not a UUID")
+    end
+  end
+
+  test "(with_template) uses the last specified template", %{email: email} do
+    last = "355d0197-ecf5-4268-aa8b-2c0502aec406"
+    email = email |> with_template(@template_id) |> with_template(last)
+    assert email.private["x-smtpapi"]["filters"]["templates"]["settings"]["template_id"] == last
+  end
+
+  test "(substitute) adds the specified tags", %{email: email} do
+    email = email |> substitute("%name%", "Jon Snow") |> substitute("%location%", "Westeros")
+    assert email.private["x-smtpapi"] == %{
+                                            "sub" => %{
+                                              "%name%" => ["Jon Snow"],
+                                              "%location%" => ["Westeros"]
+                                            }
+                                          }
+  end
+
+  test "(substitute) raises on non-binary tag", %{email: email} do
+    assert_raise FunctionClauseError, fn ->
+      email |> substitute(:name, "Jon Snow")
+    end
+  end
+
+  test "is non-dependent on function call ordering", %{email: email} do
+    email_1 = email |> with_template(@template_id) |> substitute("%name%", "Jon Snow")
+    email_2 = email |> substitute("%name%", "Jon Snow") |> with_template(@template_id)
+    assert email_1 == email_2
+  end
+end

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -15,7 +15,7 @@ defmodule Bamboo.SendgridHelperTest do
                                             "filters" => %{
                                               "templates" => %{
                                                 "settings" => %{
-                                                  "enabled" => 1,
+                                                  "enable" => 1,
                                                   "template_id" => @template_id
                                                 }
                                               }
@@ -49,6 +49,23 @@ defmodule Bamboo.SendgridHelperTest do
     assert_raise FunctionClauseError, fn ->
       email |> substitute(:name, "Jon Snow")
     end
+  end
+
+  test "is structured correctly", %{email: email} do
+    email = email |> with_template(@template_id) |> substitute("%name%", "Jon Snow")
+    assert email.private["x-smtpapi"] == %{
+                                            "filters" => %{
+                                              "templates" => %{
+                                                "settings" => %{
+                                                  "enable" => 1,
+                                                  "template_id" => @template_id
+                                                }
+                                              }
+                                            },
+                                            "sub" => %{
+                                              "%name%" => ["Jon Snow"]
+                                            }
+                                          }
   end
 
   test "is non-dependent on function call ordering", %{email: email} do


### PR DESCRIPTION
The current implementation only allows using substitution tags on a specified template. This can be used as a jumping off point for future use of the `x-smtpapi` field.
