### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-Bamboo [![Circle CI](https://circleci.com/gh/thoughtbot/bamboo/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/bamboo/tree/master) [![Coverage Status](https://coveralls.io/repos/github/thoughtbot/bamboo/badge.png?branch=master)](https://coveralls.io/github/thoughtbot/bamboo?branch=master)
+Bamboo [![Circle CI](https://circleci.com/gh/thoughtbot/bamboo/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/bamboo/tree/master) [![Coverage Status](https://coveralls.io/repos/github/thoughtbot/bamboo/badge.png?branch=master)](https://coveralls.io/github/thoughtbot/bamboo?branch=master) [![Deps Status](https://beta.hexfaktor.org/badge/all/github/thoughtbot/bamboo.svg)](https://beta.hexfaktor.org/github/thoughtbot/bamboo)
 ========
 
 Flexible and easy to use email for Elixir.


### PR DESCRIPTION
Heeeeello Thoughtbot,

I'd like to pitch you a new Elixir related badge:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/thoughtbot/bamboo.svg)](https://beta.hexfaktor.org/github/thoughtbot/bamboo)

It shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
