### PR TITLE
move preview of HTML email to a separate view

### DIFF
--- a/lib/bamboo/plug/email_preview_plug.ex
+++ b/lib/bamboo/plug/email_preview_plug.ex
@@ -50,6 +50,14 @@ defmodule Bamboo.EmailPreviewPlug do
     end
   end
 
+  get "/:id/html" do
+    if email = SentEmail.get(id) do
+      conn |> send_resp(:ok, email.html_body)
+    else
+      conn |> render(:not_found, "email_not_found.html")
+    end
+  end
+
   defp all_emails do
     SentEmail.all
   end

--- a/lib/bamboo/plug/index.html.eex
+++ b/lib/bamboo/plug/index.html.eex
@@ -159,7 +159,11 @@
         <section class="email-preview-bodies-container">
           <h3 class="email-preview-body-label">HTML body</h3>
           <p class="email-preview-body">
-            <%= @selected_email.html_body %>
+            <%= if is_nil(@selected_email.html_body) do %>
+              None
+            <% else %>
+              <a href="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>">Click Here to View</a>
+            <% end %>
           </p>
 
           <h3 class="email-preview-body-label">Text Body</h3>

--- a/lib/bamboo/plug/index.html.eex
+++ b/lib/bamboo/plug/index.html.eex
@@ -159,11 +159,13 @@
         <section class="email-preview-bodies-container">
           <h3 class="email-preview-body-label">HTML body</h3>
           <p class="email-preview-body">
-            <%= if is_nil(@selected_email.html_body) do %>
-              None
-            <% else %>
-              <a href="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>">Click Here to View</a>
-            <% end %>
+            <script>
+            function adjustFrameHeight(iframe) {
+              var body = iframe.contentWindow.document.body;
+              iframe.style.height = (body.scrollHeight + body.offsetHeight - body.clientHeight) + "px";
+            }
+            </script>
+            <iframe width="100%" onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
           </p>
 
           <h3 class="email-preview-body-label">Text Body</h3>

--- a/lib/bamboo/plug/index.html.eex
+++ b/lib/bamboo/plug/index.html.eex
@@ -13,6 +13,11 @@
         font-family: sans-serif;
       }
 
+      iframe {
+        width: 100%;
+        border: none;
+      }
+
       .truncate {
         white-space: nowrap;
         overflow: hidden;
@@ -165,7 +170,7 @@
               iframe.style.height = (body.scrollHeight + body.offsetHeight - body.clientHeight) + "px";
             }
             </script>
-            <iframe width="100%" onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
+            <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
           </p>
 
           <h3 class="email-preview-body-label">Text Body</h3>

--- a/test/lib/bamboo/plug/email_preview_plug_test.exs
+++ b/test/lib/bamboo/plug/email_preview_plug_test.exs
@@ -89,6 +89,17 @@ defmodule Bamboo.EmailPreviewTest do
     refute showing_in_preview_pane?(conn, SentEmail.get(unselected_email_id))
   end
 
+  test "shows an email's html by id" do
+    normalize_and_push_pair(:html_email)
+    selected_email_id = SentEmail.all |> Enum.at(0) |> SentEmail.get_id
+    conn = conn(:get, "/sent_emails/foo/#{selected_email_id}/html")
+
+    conn = AppRouter.call(conn, nil)
+
+    assert conn.status == 200
+    assert conn.resp_body =~ SentEmail.get(selected_email_id).html_body
+  end
+
   test "shows error if email could not be found" do
     conn = conn(:get, "/sent_emails/foo/non_existent_id")
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,4 +8,12 @@ defmodule Bamboo.Factory do
       subject: sequence("Email subject")
     }
   end
+
+  def factory(:html_email) do
+    %Bamboo.Email{
+      from: sequence(:email, &"from-#{&1}@gmail.com"),
+      subject: sequence("Email subject"),
+      html_body: "<p>ohai!</p>"
+    }
+  end
 end


### PR DESCRIPTION
When previewing HTML emails that include their own styles, the current implementation will allow said styles to "leak" out and disrupt the preview index styles. Example:

![2016-06-01 at 10 49 am](https://cloud.githubusercontent.com/assets/8212/15717061/e057adde-27ea-11e6-8f34-e798038464c1.png)

To plug the leak, I've moved the HTML previews to their own view altogether. Example:

![2016-06-01 at 11 22 am](https://cloud.githubusercontent.com/assets/8212/15717105/1f4a965a-27eb-11e6-8ebd-99127add79d6.png)

Other possible ways to resolve this:

1. Shadow DOM – I went down this route and got it working, only to find that you cannot have a `<link>` element in a shadow tree. This kills anyone using external styles (and letting their delivery provider inline them).
2. iframe – I think this might work if we set the html body to the `srcdoc` attribute, but my first pass failed and then we'd have to resize the iframes to fit the content. Seems kludgy.

I'm open to whatever works best. Just holler and I'l make adjustments as necessary. 🍻 