### PR TITLE
Mandrill Template Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ Here is what it looks like:
 
 ![Screenshot of BambooEmailPreview](https://cloud.githubusercontent.com/assets/22394/14929083/bda60b76-0e29-11e6-9e11-5ec60069e825.png)
 
-## Mandrill Specific Functionality (tags, merge vars, etc.)
+## Mandrill Specific Functionality (tags, merge vars, templates, etc.)
 
 Mandrill offers extra features on top of regular SMTP email like tagging, merge
-vars, and scheduling emails to send in the future. See
+vars, templates, and scheduling emails to send in the future. See
 [Bamboo.MandrillHelper](https://hexdocs.pm/bamboo/Bamboo.MandrillHelper.html).
 
 ## Heroku Configuration

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -92,7 +92,15 @@ defmodule Bamboo.MandrillAdapter do
 
   defp convert_to_mandrill_params(email, api_key) do
     %{key: api_key, message: message_params(email)}
+    |> maybe_put_template_params(email)
   end
+
+  defp maybe_put_template_params(params, %{private: %{template_name: template_name, template_content: template_content}}) do
+    params
+    |> Map.put(:template_name, template_name)
+    |> Map.put(:template_content, template_content)
+  end
+  defp maybe_put_template_params(params, _), do: params
 
   defp message_params(email) do
     %{

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -21,6 +21,7 @@ defmodule Bamboo.MandrillAdapter do
 
   @default_base_uri "https://mandrillapp.com/"
   @send_message_path "api/1.0/messages/send.json"
+  @send_message_template_path "api/1.0/messages/send-template.json"
   @behaviour Bamboo.Adapter
 
   defmodule ApiError do
@@ -56,7 +57,7 @@ defmodule Bamboo.MandrillAdapter do
   def deliver(email, config) do
     api_key = get_key(config)
     params = email |> convert_to_mandrill_params(api_key) |> Poison.encode!
-    case request!(@send_message_path, params) do
+    case request!(api_path(email), params) do
       %{status_code: status} = response when status > 299 ->
         raise(ApiError, %{params: params, response: response})
       response -> response
@@ -129,6 +130,9 @@ defmodule Bamboo.MandrillAdapter do
       }]
     end)
   end
+
+  defp api_path(%{private: %{template_name: _}}), do: @send_message_template_path
+  defp api_path(_), do: @send_message_path
 
   defp headers do
     %{"content-type" => "application/json"}

--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -1,6 +1,6 @@
 defmodule Bamboo.MandrillHelper do
   @moduledoc """
-  Functions for using features specific to Mandrill e.g. tagging, merge vars
+  Functions for using features specific to Mandrill e.g. tagging, merge vars, templates
   """
 
   alias Bamboo.Email
@@ -47,5 +47,24 @@ defmodule Bamboo.MandrillHelper do
   """
   def tag(email, tags) do
     put_param(email, "tags", List.wrap(tags))
+  end
+
+  @doc """
+  Send emails using Mandrill's template API.
+
+  Setup Mandrill to send using a named template with template content. Use this
+  in conjuction with merge vars to offload template rendering to Mandrill. The
+  template name specified here must match the template name stored in Mandrill.
+  Mandrill's API docs for this can be found [here](https://www.mandrillapp.com/api/docs/messages.JSON.html#method=send-template).
+
+  ## Example
+
+      template(email, "welcome")
+      template(email, "welcome", [%{"name" => "Name", "content" => "John"}])
+  """
+  def template(email, template_name, template_content \\ []) do
+    email
+    |> Email.put_private(:template_name, template_name)
+    |> Email.put_private(:template_content, template_content)
   end
 end

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -141,6 +141,28 @@ defmodule Bamboo.MandrillAdapterTest do
     assert message["important"] == true
   end
 
+  test "deliver/2 puts template name and empty content" do
+    email = new_email |> MandrillHelper.template("hello")
+
+    email |> MandrillAdapter.deliver(@config)
+
+    assert_receive {:fake_mandrill, %{params: %{"template_name" => template_name, "template_content" => template_content}}}
+    assert template_name == "hello"
+    assert template_content == []
+  end
+
+  test "deliver/2 puts template name and content" do
+    email = new_email |> MandrillHelper.template("hello", [
+      %{name: 'example name', content: 'example content'}
+    ])
+
+    email |> MandrillAdapter.deliver(@config)
+
+    assert_receive {:fake_mandrill, %{params: %{"template_name" => template_name, "template_content" => template_content}}}
+    assert template_name == "hello"
+    assert template_content == [%{"content" => 'example content', "name" => 'example name'}]
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 

--- a/test/lib/bamboo/adapters/mandrill_helper_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_helper_test.exs
@@ -16,4 +16,12 @@ defmodule Bamboo.MandrillHelperTest do
     email = new_email |> MandrillHelper.tag(["welcome-email", "awesome"])
     assert email.private.message_params == %{"tags" => ["welcome-email", "awesome"]}
   end
+
+  test "adds template information to mandrill emails" do
+    email = new_email |> MandrillHelper.template("welcome", [%{"name" => "example_name", "content" => "example_content"}])
+    assert email.private == %{template_name: "welcome", template_content: [%{"name" => "example_name", "content" => "example_content"}]}
+
+    email = new_email |> MandrillHelper.template("welcome")
+    assert email.private == %{template_name: "welcome", template_content: []}
+  end
 end


### PR DESCRIPTION
Adds the ability to use Mandrill's [built in template support](https://mandrillapp.com/api/docs/messages.JSON.html#method=send-template). This means template rendering can be fully offloaded to Mandrill. This is done by adding a template function to `MandrillHelper` that inserts template config into the private params. These params are detected when trying to deliver the email which switches over the API path and inserts params into the request.

Here is an example of how it can be used below. Please note the only new public api is `Bamboo.MandrillHelper.template` the rest of the config can be done using existing functions.

``` elixir
new_email
|> to("john@example.com")
|> from("no-reply@service.com")
|> Bamboo.MandrillHelper.template("invoice")
|> Bamboo.MandrillHelper.put_param("merge_language", "handlebars")
|> Bamboo.MandrillHelper.put_param("global_merge_vars", [ %{ "name": "reference_number", "content": "ABC001" }])
|> Mailer.deliver_now
```

Tests are included and this is working against a production Mandrill account. Regular message sending via the API is unaffected by this change.