### PR TITLE
Add attachment support to Mandrill Adapter.

### DIFF
--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -101,7 +101,8 @@ defmodule Bamboo.MandrillAdapter do
       subject: email.subject,
       text: email.text_body,
       html: email.html_body,
-      headers: email.headers
+      headers: email.headers,
+      attachments: attachments(email)
     }
     |> add_message_params(email)
   end
@@ -112,6 +113,18 @@ defmodule Bamboo.MandrillAdapter do
     end)
   end
   defp add_message_params(mandrill_message, _), do: mandrill_message
+
+  defp attachments(%{attachments: attachments}) do
+    attachments
+    |> Enum.reverse
+    |> Enum.map(fn(att) ->
+      %{
+        name: att.filename,
+        type: att.content_type,
+        content: Base.encode64(File.read!(att.path))
+      }
+    end)
+  end
 
   defp recipients(email) do
     []

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -78,7 +78,7 @@ defmodule Bamboo.MandrillAdapterTest do
     assert request_path == "/api/1.0/messages/send.json"
   end
 
-  test "deliver/2 sends from, html and text body, subject, and headers" do
+  test "deliver/2 sends from, html and text body, subject, headers and attachment" do
     email = new_email(
       from: {"From", "from@foo.com"},
       subject: "My Subject",
@@ -86,6 +86,7 @@ defmodule Bamboo.MandrillAdapterTest do
       html_body: "HTML BODY",
     )
     |> Email.put_header("Reply-To", "reply@foo.com")
+    |> Email.put_attachment(Path.join(__DIR__, "../../../support/attachment.txt"))
 
     email |> MandrillAdapter.deliver(@config)
 
@@ -98,6 +99,13 @@ defmodule Bamboo.MandrillAdapterTest do
     assert message["text"] == email.text_body
     assert message["html"] == email.html_body
     assert message["headers"] == email.headers
+    assert message["attachments"] == [
+      %{
+        "type" => "text/plain",
+        "name" => "attachment.txt",
+        "content" => "VGVzdCBBdHRhY2htZW50Cg=="
+      }
+    ]
   end
 
   test "deliver/2 correctly formats recipients" do

--- a/test/support/attachment.txt
+++ b/test/support/attachment.txt
@@ -1,0 +1,1 @@
+Test Attachment


### PR DESCRIPTION
This is a follow up addition of PR #156 to support attachment(#53).

Once the attachment support is merged, this PR will add attachment support to Mandrill adapter.
