### PR TITLE
Promote thoughtbot's Elixir experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Bamboo [![Circle CI](https://circleci.com/gh/thoughtbot/bamboo/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/bamboo/tree/master) [![Coverage Status](https://coveralls.io/repos/github/thoughtbot/bamboo/badge.png?branch=master)](https://coveralls.io/github/thoughtbot/bamboo?branch=master)
 ========
 
+**Bamboo is part of the [thoughtbot Elixir family][elixir-phoenix] of projects.**
+
 Flexible and easy to use email for Elixir.
 
 * **Adapter based** so it can be used with Mandrill, SMTP, or whatever else you want. Comes with a Mandrill adapter out of the box.
@@ -263,11 +265,11 @@ Bamboo.TestAdapter.
 Bamboo is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
-We love open source software!
-See [our other projects][community] or
-[hire us][hire] to design, develop, and grow your product.
+We love open source software, Elixir, and Phoenix. See [our other Elixir
+projects][elixir-phoenix], or [hire our Elixir Phoenix development team][hire]
+to design, develop, and grow your product.
 
-[community]: https://thoughtbot.com/community?utm_source=github
+[elixir-phoenix]: https://thoughtbot.com/services/elixir-phoenix?utm_source=github
 [hire]: https://thoughtbot.com?utm_source=github
 
 ## Contributing


### PR DESCRIPTION
We love working with Elixir and Phoenix and want to call attention
specifically to our experience with those technologies. Our
`elixir-phoenix` landing page has open source projects, blog posts, and
information on why we love Elixir.