### PR TITLE
Remove warnings-as-errors until deps are updated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,3 @@ dependencies:
 test:
   override:
     - mix test
-    - MIX_ENV=prod mix compile --warnings-as-errors


### PR DESCRIPTION
Right now CI isn't passing due to some deps that have warnings under the new version of Erlang. So I'll remove this and add it back in once we've had a chance to figure get it passing without any warnings again. For now this is making it harder for contributors to get things in so I'll remove it.