### PR TITLE
Send "" to preview if HTML body is nil

### DIFF
--- a/lib/bamboo/plug/email_preview_plug.ex
+++ b/lib/bamboo/plug/email_preview_plug.ex
@@ -52,7 +52,7 @@ defmodule Bamboo.EmailPreviewPlug do
 
   get "/:id/html" do
     if email = SentEmail.get(id) do
-      conn |> send_resp(:ok, email.html_body)
+      conn |> send_resp(:ok, email.html_body || "")
     else
       conn |> render(:not_found, "email_not_found.html")
     end

--- a/test/lib/bamboo/plug/email_preview_plug_test.exs
+++ b/test/lib/bamboo/plug/email_preview_plug_test.exs
@@ -100,6 +100,17 @@ defmodule Bamboo.EmailPreviewTest do
     assert conn.resp_body =~ SentEmail.get(selected_email_id).html_body
   end
 
+  test "sends an empty body for html emails if html body is nil" do
+    normalize_and_push_pair(:email, html_body: nil)
+    selected_email_id = SentEmail.all |> Enum.at(0) |> SentEmail.get_id
+    conn = conn(:get, "/sent_emails/foo/#{selected_email_id}/html")
+
+    conn = AppRouter.call(conn, nil)
+
+    assert conn.status == 200
+    assert conn.resp_body == ""
+  end
+
   test "shows error if email could not be found" do
     conn = conn(:get, "/sent_emails/foo/non_existent_id")
 


### PR DESCRIPTION
Fixes: #182

PR #172 added support for loading HTML previews in an iframe. The problem
is that emails that have no html_body result in an error because the
response body cannot be nil:

This PR fixes it by using an empty string if no html_body is present