### PR TITLE
Refactor base uri

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,3 @@
 use Mix.Config
 
-config :logger, level: :warn
-
 import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,5 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :bamboo, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:bamboo, :key)
-#
-# Or configure a 3rd-party app:
-#
 config :logger, level: :warn
-#
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :logger, level: :warn

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,8 @@
+use Mix.Config
+
+config :logger, level: :info
+
+config :bamboo,
+  mailgun_base_uri: "http://localhost:8765/",
+  mandrill_base_uri: "http://localhost:8765/",
+  sendgrid_base_uri: "http://localhost:8765"

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -19,7 +19,8 @@ defmodule Bamboo.MailgunAdapter do
       end
   """
 
-  @base_uri "https://api.mailgun.net/v3/"
+  @default_base_uri "https://api.mailgun.net/v3/"
+  @base_uri Application.get_env(:bamboo, :mailgun_base_uri, @default_base_uri)
   @behaviour Bamboo.Adapter
 
   alias Bamboo.Email
@@ -123,7 +124,6 @@ defmodule Bamboo.MailgunAdapter do
   defp put_text_body(body, %Email{text_body: text_body}), do: Map.put(body, :text, text_body)
 
   defp full_uri(config) do
-    (Application.get_env(:bamboo, :mailgun_base_uri) || @base_uri)
-    <> config.domain <> "/messages"
+    @base_uri <> config.domain <> "/messages"
   end
 end

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -20,6 +20,7 @@ defmodule Bamboo.MandrillAdapter do
   """
 
   @default_base_uri "https://mandrillapp.com/"
+  @base_uri Application.get_env(:bamboo, :mandrill_base_uri, @default_base_uri)
   @send_message_path "api/1.0/messages/send.json"
   @send_message_template_path "api/1.0/messages/send-template.json"
   @behaviour Bamboo.Adapter
@@ -147,10 +148,6 @@ defmodule Bamboo.MandrillAdapter do
   end
 
   defp request!(path, params) do
-    HTTPoison.post!("#{base_uri}/#{path}", params, headers)
-  end
-
-  defp base_uri do
-    Application.get_env(:bamboo, :mandrill_base_uri) || @default_base_uri
+    HTTPoison.post!(@base_uri <> path, params, headers)
   end
 end

--- a/lib/bamboo/adapters/sendgrid_adapter.ex
+++ b/lib/bamboo/adapters/sendgrid_adapter.ex
@@ -19,6 +19,7 @@ defmodule Bamboo.SendgridAdapter do
   """
 
   @default_base_uri "https://api.sendgrid.com/api"
+  @base_uri Application.get_env(:bamboo, :sendgrid_base_uri, @default_base_uri)
   @send_message_path "/mail.send.json"
   @behaviour Bamboo.Adapter
 
@@ -58,7 +59,7 @@ defmodule Bamboo.SendgridAdapter do
     api_key = get_key(config)
     body = email |> to_sendgrid_body |> Plug.Conn.Query.encode
 
-    case HTTPoison.post!(base_uri <> @send_message_path, body, headers(api_key)) do
+    case HTTPoison.post!(@base_uri <> @send_message_path, body, headers(api_key)) do
       %{status_code: status} = response when status > 299 ->
         raise(ApiError, %{params: body, response: response})
       response -> response
@@ -159,9 +160,5 @@ defmodule Bamboo.SendgridAdapter do
   defp list_empty?([]), do: true
   defp list_empty?(list) do
     Enum.all?(list, fn(el) -> el == "" || el == nil end)
-  end
-
-  defp base_uri do
-    Application.get_env(:bamboo, :sendgrid_base_uri) || @default_base_uri
   end
 end

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -10,7 +10,11 @@ defmodule Bamboo.MailgunAdapterTest do
 
   setup do
     FakeEndpoint.start_server
-    FakeEndpoint.register("mailgun", self())
+    FakeEndpoint.register(self(), %{
+      name: "mailgun",
+      params_path: ["from"],
+      request_path: "/test.tt/messages"
+    })
 
     :ok
   end

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -10,7 +10,14 @@ defmodule Bamboo.MandrillAdapterTest do
 
   setup do
     FakeEndpoint.start_server
-    FakeEndpoint.register("mandrill", self())
+    FakeEndpoint.register(self(), %{
+      name: "mandrill",
+      params_path: ["message", "from_email"],
+      request_path: [
+        "/api/1.0/messages/send.json",
+        "/api/1.0/messages/send-template.json"
+      ]
+    })
 
     :ok
   end

--- a/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
@@ -9,7 +9,11 @@ defmodule Bamboo.SendgridAdapterTest do
 
   setup do
     FakeEndpoint.start_server
-    FakeEndpoint.register("sendgrid", self())
+    FakeEndpoint.register(self(), %{
+      name: "sendgrid",
+      params_path: ["from"],
+      request_path: "/mail.send.json"
+    })
 
     :ok
   end

--- a/test/support/fake_endpoint.ex
+++ b/test/support/fake_endpoint.ex
@@ -1,0 +1,56 @@
+defmodule Bamboo.FakeEndpoint do
+  use Plug.Router
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison
+  plug :match
+  plug :dispatch
+
+  def start_server do
+    unless __MODULE__ in Process.registered do
+      Agent.start_link(&Map.new/0, name: __MODULE__)
+    end
+
+    Plug.Adapters.Cowboy.http __MODULE__, [], port: 8765, ref: __MODULE__
+  end
+
+  def register(name, pid) do
+    Agent.update(__MODULE__, &Map.put(&1, name, pid))
+  end
+
+  post "/test.tt/messages" do
+    case Map.get(conn.params, "from") do
+      "INVALID_EMAIL" -> send_resp(conn, 500, "Error!!")
+      _ -> send_resp(conn, 200, "SENT")
+    end |> send_to_parent("mailgun")
+  end
+
+  post "/api/1.0/messages/send.json" do
+    case get_in(conn.params, ["message", "from_email"]) do
+      "INVALID_EMAIL" -> conn |> send_resp(500, "Error!!")
+      _ -> conn |> send_resp(200, "SENT")
+    end |> send_to_parent("mandrill")
+  end
+
+  post "/api/1.0/messages/send-template.json" do
+    case get_in(conn.params, ["message", "from_email"]) do
+      "INVALID_EMAIL" -> conn |> send_resp(500, "Error!!")
+      _ -> conn |> send_resp(200, "SENT")
+    end |> send_to_parent("mandrill")
+  end
+
+  post "/mail.send.json" do
+    case Map.get(conn.params, "from") do
+      "INVALID_EMAIL" -> conn |> send_resp(500, "Error!!")
+      _ -> conn |> send_resp(200, "SENT")
+    end |> send_to_parent("sendgrid")
+  end
+
+  defp send_to_parent(conn, which) do
+    parent = Agent.get(__MODULE__, fn(map) -> Map.get(map, which) end)
+    send parent, {:fake_endpoint, conn}
+    conn
+  end
+end


### PR DESCRIPTION
- Move base uri resolution to compile time
- Refactor and fix tests
- Extract the common part (Fake...) into a separate module

I've made sure the adapter tests are not coupled with the fake endpoint in https://github.com/thoughtbot/bamboo/pull/192/commits/2ae71d351bb2bee78a99cf16356749caa7839c04 with a tiny bit of meta. So later on when you want to extract the adapters out of the main project, you can simply move the adapter tests out with their respective source code.