### PR TITLE
make ex_machina dep for test only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Bamboo.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.0"},
-      {:ex_machina, "~> 1.0"},
+      {:ex_machina, "~> 1.0", only: :test},
       {:cowboy, "~> 1.0", only: [:test, :dev]},
       {:phoenix, "~> 1.1", only: :test},
       {:phoenix_html, "~> 2.2", only: :test},


### PR DESCRIPTION
This was causing unnecessary dependency conflicts