### PR TITLE
Fixed typo in test helper documentation

### DIFF
--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -69,7 +69,7 @@ defmodule Bamboo.Test do
           email |> MyApp.Mailer.deliver_now
 
           # Works with deliver_now and deliver_later
-          assert_delivered_email MyAppEmail.welcome_email(user)
+          assert_delivered_email MyApp.Email.welcome_email(user)
         end
       end
   """


### PR DESCRIPTION
One character fix, but it makes this part of the documentation make more sense. 😄 