### PR TITLE
Fixes #174 - Set "text/html" Response Content Type for EmailPreviewPlug

### DIFF
--- a/lib/bamboo/plug/email_preview_plug.ex
+++ b/lib/bamboo/plug/email_preview_plug.ex
@@ -52,7 +52,9 @@ defmodule Bamboo.EmailPreviewPlug do
 
   get "/:id/html" do
     if email = SentEmail.get(id) do
-      conn |> send_resp(:ok, email.html_body || "")
+      conn
+      |> Plug.Conn.put_resp_content_type("text/html")
+      |> send_resp(:ok, email.html_body || "")
     else
       conn |> render(:not_found, "email_not_found.html")
     end


### PR DESCRIPTION
Change: Added Pipe for |> Plug.Conn.put_resp_content_type("text/html")
Rationale: When getting "/:id/html" set the response content type to "text/html"

Fixes issue where the iframe in `index.html.eex` interprets the source as 'text' and embeds in a set of`<pre></pre>` tags, such that HTML tags aren't rendered.

Issued occurred for me on:
Chrome - Version 51.0.2704.103 (64-bit)
Safari - Version 9.1.2 (11601.7.6)