### PR TITLE
Add PostmarkAdapter to README and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ to open an issue or a PR if you'd like to add a new adapter to the list.
 * `Bamboo.SendgridAdapter` - Ships with Bamboo.
 * `Bamboo.SMTPAdapter` - See [fewlinesco/bamboo_smtp](https://github.com/fewlinesco/bamboo_smtp).
 * `Bamboo.SparkPostAdapter` - See [andrewtimberlake/bamboo_sparkpost](https://github.com/andrewtimberlake/bamboo_sparkpost).
+* `Bamboo.PostmarkAdapter` - See [pablo-co/bamboo_postmark](https://github.com/pablo-co/bamboo_postmark).
 * `Bamboo.LocalAdapter` - Ships with Bamboo. Stores email in memory. Great for local development.
 * `Bamboo.TestAdapter` - Ships with Bamboo. Use in your test environment.
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Bamboo.Mixfile do
      preferred_cli_env: ["coveralls": :test, "coveralls.circle": :test],
      elixirc_paths: elixirc_paths(Mix.env),
      description: "Straightforward, powerful, and adapter based Elixir email library." <>
-     " Works with Mandrill, Mailgun, SendGrid, SparkPost, in-memory, and test.",
+     " Works with Mandrill, Mailgun, SendGrid, SparkPost, Postmark, in-memory, and test.",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package,


### PR DESCRIPTION
I created an adapter for [Postmark](https://postmarkapp.com/) which I've been using on production for a couple of weeks without a problem.

I decided to extract the adapter into it's own project so that others using Postmark can benefit from API only features such as templates. This change adds a reference to the adapter in the README and in the project's description.