### PR TITLE
Use case-insensitive sent email ID lookup

### DIFF
--- a/lib/bamboo/sent_email.ex
+++ b/lib/bamboo/sent_email.ex
@@ -89,7 +89,7 @@ defmodule Bamboo.SentEmail do
 
   defp do_get(id) do
     Enum.find all, nil, fn(email) ->
-      get_id(email) == id
+      email |> get_id |> String.downcase == String.downcase(id)
     end
   end
 

--- a/test/lib/bamboo/sent_email_test.exs
+++ b/test/lib/bamboo/sent_email_test.exs
@@ -37,6 +37,15 @@ defmodule Bamboo.SentEmailTest do
     assert %Bamboo.Email{subject: "Something"} = email
   end
 
+  test "get is case-insensitive" do
+    pushed_email = SentEmail.push(new_email(subject: "Something"))
+
+    id = SentEmail.get_id(pushed_email)
+
+    assert pushed_email == id |> String.upcase   |> SentEmail.get
+    assert pushed_email == id |> String.downcase |> SentEmail.get
+  end
+
   test "returns nil when getting email with no matching id" do
     assert SentEmail.get("non_existent_id") == nil
   end


### PR DESCRIPTION
This addresses #212, where the Email Preview was rendered unusable behind an endpoint with lowercase path rewrite (a common practice).