### PR TITLE
Update README.md to specify the domain configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ is done to make testing easier and to make emails easy to pipe/compose.
 # In your config/config.exs file
 config :my_app, MyApp.Mailer,
   adapter: Bamboo.MandrillAdapter,
-  api_key: "my_api_key"
-
+  api_key: "my_api_key",
+  domain: "my-domain.com" # Set the domain in case you're using Mailgun
+  
 # Somewhere in your application
 defmodule MyApp.Mailer do
   use Bamboo.Mailer, otp_app: :my_app


### PR DESCRIPTION
I couldn't find anywhere that said that for Mailgun it was necessary to include the domain on the Bamboo configuration.
