### PR TITLE
Mandrill Merge Vars

### DIFF
--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -36,6 +36,58 @@ defmodule Bamboo.MandrillHelper do
   end
 
   @doc """
+  Set merge_vars that are used by Mandrill 
+
+  A convenience function for: 
+
+      email
+      |> put_param(email, "merge_vars", [
+        %{
+          rcpt: "user1@example.com",
+          vars: [
+            %{
+              "name": "full_name",
+              "content": "User 1"
+            }
+          ]
+        },
+        %{
+          rcpt: "user2@example.com",
+          vars: [
+            %{
+              "name": "full_name",
+              "content": "User 2"
+            }
+          ]
+        }
+      ])
+
+  ## Example
+
+      put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
+  """
+  def put_merge_vars(email, enumerable, fun) do
+    merge_vars = Enum.map(enumerable, fn(e) ->
+      %{
+        rcpt: e.email,
+        vars: merge_vars(e, fun)
+      }
+    end)
+
+    email |> put_param("merge_vars", merge_vars)
+  end
+
+  defp merge_vars(e, fun) do
+    fun.(e)
+    |> Enum.map(fn({ key, value }) ->
+      %{
+        "name": to_string(key),
+        "content": value
+      }
+    end)
+  end
+
+  @doc """
   Set a single tag or multiple tags for an email.
 
   A convenience function for `put_param(email, "tags", ["my-tag"])`

--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -38,6 +38,11 @@ defmodule Bamboo.MandrillHelper do
   @doc """
   Set merge_vars that are used by Mandrill 
 
+  ## Example
+
+      email
+      |> put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
+
   A convenience function for: 
 
       email
@@ -61,11 +66,6 @@ defmodule Bamboo.MandrillHelper do
           ]
         }
       ])
-
-  ## Example
-
-      email
-      |> put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
   """
   def put_merge_vars(email, enumerable, fun) do
     merge_vars = Enum.map(enumerable, fn(e) ->

--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -64,7 +64,8 @@ defmodule Bamboo.MandrillHelper do
 
   ## Example
 
-      put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
+      email
+      |> put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
   """
   def put_merge_vars(email, enumerable, fun) do
     merge_vars = Enum.map(enumerable, fn(e) ->

--- a/test/lib/bamboo/adapters/mandrill_helper_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_helper_test.exs
@@ -21,8 +21,9 @@ defmodule Bamboo.MandrillHelperTest do
       }
     ]
 
-    email = new_email
-    |> MandrillHelper.put_merge_vars(users, fn(user) -> %{ full_name: user.full_name } end)
+    email = MandrillHelper.put_merge_vars new_email, users, fn(user) ->
+      %{full_name: user.full_name}
+    end
 
     assert email.private.message_params == %{"merge_vars" => [
         %{

--- a/test/lib/bamboo/adapters/mandrill_helper_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_helper_test.exs
@@ -9,6 +9,44 @@ defmodule Bamboo.MandrillHelperTest do
     assert email.private.message_params == %{"track_links" => true}
   end
 
+  test "put_merge_vars/3 puts a list of merge_vars in private.merge_vars" do
+    users = [
+      %{
+        email: "user1@example.com",
+        full_name: "User 1"
+      },
+      %{
+        email: "user2@example.com",
+        full_name: "User 2"
+      }
+    ]
+
+    email = new_email
+    |> MandrillHelper.put_merge_vars(users, fn(user) -> %{ full_name: user.full_name } end)
+
+    assert email.private.message_params == %{"merge_vars" => [
+        %{
+          rcpt: "user1@example.com",
+          vars: [
+            %{
+              "name": "full_name",
+              "content": "User 1"
+            }
+          ]
+        },
+        %{
+          rcpt: "user2@example.com",
+          vars: [
+            %{
+              "name": "full_name",
+              "content": "User 2"
+            }
+          ]
+        }
+      ]
+    }
+  end
+
   test "adds tags to mandrill emails" do
     email = new_email |> MandrillHelper.tag("welcome-email")
     assert email.private.message_params == %{"tags" => ["welcome-email"]}


### PR DESCRIPTION
This PR resolves #39 

Adds a function to easily add  *Mandrill Merge Vars* to an email.

Example:

```elixir
email |> put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
```