### PR TITLE
Adds general Bamboo.ApiError and updates adapters to use it

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -23,14 +23,14 @@ defmodule Bamboo.MailgunAdapter do
   @behaviour Bamboo.Adapter
 
   alias Bamboo.Email
-  alias Bamboo.ApiError
+  import Bamboo.ApiError
 
   def deliver(email, config) do
     body = email |> to_mailgun_body |> Plug.Conn.Query.encode
 
     case :hackney.post(full_uri(config), headers(config), body, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
-        raise_api_error(body, response)
+        raise_api_error(__MODULE__, response, body)
       {:ok, status, headers, response} ->
         %{status_code: status, headers: headers, body: response}
       {:error, reason} ->
@@ -46,24 +46,6 @@ defmodule Bamboo.MailgunAdapter do
       end
     end
     config
-  end
-
-  defp raise_api_error(message), do: raise(ApiError, message: message)
-  defp raise_api_error(params, response) do
-    message = """
-    There was a problem sending the email through the Mailgun API.
-
-    Here is the response:
-
-    #{inspect response, limit: :infinity}
-
-
-    Here are the params we sent:
-
-    #{inspect params, limit: :infinity}
-    """
-
-    raise(ApiError, message: message)
   end
 
   defp raise_missing_setting_error(config, setting) do

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -19,6 +19,7 @@ defmodule Bamboo.MailgunAdapter do
       end
   """
 
+  @service_name "Mailgun"
   @base_uri "https://api.mailgun.net/v3/"
   @behaviour Bamboo.Adapter
 
@@ -30,7 +31,7 @@ defmodule Bamboo.MailgunAdapter do
 
     case :hackney.post(full_uri(config), headers(config), body, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
-        raise_api_error(__MODULE__, response, body)
+        raise_api_error(@service_name, response, body)
       {:ok, status, headers, response} ->
         %{status_code: status, headers: headers, body: response}
       {:error, reason} ->

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -24,30 +24,7 @@ defmodule Bamboo.MandrillAdapter do
   @send_message_template_path "api/1.0/messages/send-template.json"
   @behaviour Bamboo.Adapter
 
-  defmodule ApiError do
-    defexception [:message]
-
-    def exception(%{message: message}) do
-      %ApiError{message: message}
-    end
-
-    def exception(%{params: params, response: response}) do
-      filtered_params = params |> Poison.decode! |> Map.put("key", "[FILTERED]")
-
-      message = """
-      There was a problem sending the email through the Mandrill API.
-
-      Here is the response:
-
-      #{inspect response, limit: :infinity}
-
-      Here are the params we sent:
-
-      #{inspect filtered_params, limit: :infinity}
-      """
-      %ApiError{message: message}
-    end
-  end
+  alias Bamboo.ApiError
 
   def deliver(email, config) do
     api_key = get_key(config)
@@ -56,11 +33,11 @@ defmodule Bamboo.MandrillAdapter do
 
     case :hackney.post(uri, headers(), params, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
-        raise(ApiError, %{params: params, response: response})
+        raise_api_error(params, response)
       {:ok, status, headers, response} ->
         %{status_code: status, headers: headers, body: response}
       {:error, reason} ->
-        raise(ApiError, %{message: inspect(reason)})
+        raise_api_error(inspect(reason))
     end
   end
 
@@ -78,6 +55,34 @@ defmodule Bamboo.MandrillAdapter do
       nil -> raise_api_key_error(config)
       key -> key
     end
+  end
+
+  defp raise_api_error(message), do: raise(ApiError, message: message)
+  defp raise_api_error(params, response) do
+    filtered_params = params |> Poison.decode! |> Map.put("key", "[FILTERED]")
+
+    message = """
+    There was a problem sending the email through the Mandrill API.
+
+    Here is the response:
+
+    #{inspect response, limit: :infinity}
+
+    Here are the params we sent:
+
+    #{inspect filtered_params, limit: :infinity}
+
+    If you are deploying to Heroku and using ENV variables to handle your API key,
+    you will need to explicitly export the variables so they are available at compile time.
+    Add the following configuration to your elixir_buildpack.config:
+
+    config_vars_to_export=(
+      DATABASE_URL
+      MANDRILL_API_KEY
+    )
+    """
+
+    raise(ApiError, message: message)
   end
 
   defp raise_api_key_error(config) do

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -19,19 +19,10 @@ defmodule Bamboo.MandrillAdapter do
       end
   """
 
+  @service_name "Mandrill"
   @default_base_uri "https://mandrillapp.com"
   @send_message_path "api/1.0/messages/send.json"
   @send_message_template_path "api/1.0/messages/send-template.json"
-  @extra_api_error_message """
-  If you are deploying to Heroku and using ENV variables to handle your API key,
-  you will need to explicitly export the variables so they are available at compile time.
-  Add the following configuration to your elixir_buildpack.config:
-
-  config_vars_to_export=(
-    DATABASE_URL
-    MANDRILL_API_KEY
-  )
-  """
   @behaviour Bamboo.Adapter
 
   import Bamboo.ApiError
@@ -44,7 +35,7 @@ defmodule Bamboo.MandrillAdapter do
     case :hackney.post(uri, headers(), params, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
         filtered_params = params |> Poison.decode! |> Map.put("key", "[FILTERED]")
-        raise_api_error(__MODULE__, response, filtered_params, @extra_api_error_message)
+        raise_api_error(@service_name, response, filtered_params)
       {:ok, status, headers, response} ->
         %{status_code: status, headers: headers, body: response}
       {:error, reason} ->

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -23,18 +23,9 @@ defmodule Bamboo.SendGridAdapter do
       end
   """
 
+  @service_name "SendGrid"
   @default_base_uri "https://api.sendgrid.com/api"
   @send_message_path "/mail.send.json"
-  @extra_api_error_message """
-  If you are deploying to Heroku and using ENV variables to handle your API key,
-  you will need to explicitly export the variables so they are available at compile time.
-  Add the following configuration to your elixir_buildpack.config:
-
-  config_vars_to_export=(
-    DATABASE_URL
-    SENDGRID_API_KEY
-  )
-  """
   @behaviour Bamboo.Adapter
 
   alias Bamboo.Email
@@ -48,7 +39,7 @@ defmodule Bamboo.SendGridAdapter do
     case :hackney.post(url, headers(api_key), body, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
         filtered_params = body |> Plug.Conn.Query.decode |> Map.put("key", "[FILTERED]")
-        raise_api_error(__MODULE__, response, filtered_params, @extra_api_error_message)
+        raise_api_error(@service_name, response, filtered_params)
       {:ok, status, headers, response} ->
         %{status_code: status, headers: headers, body: response}
       {:error, reason} ->

--- a/lib/bamboo/api_error.ex
+++ b/lib/bamboo/api_error.ex
@@ -5,6 +5,40 @@ defmodule Bamboo.ApiError do
 
   defexception [:message]
 
+  @doc """
+  Raises an `ApiError` with the given `message` or `service_name`, `response` and `params`.
+
+  An extra error message can be added using a fourth parameter `extra_message`.
+
+  ## Examples
+
+      iex> raise_api_error("Error message")
+      ** (Bamboo.ApiError) Error Message
+
+      iex> raise_api_error(service_name, response, params)
+      ** (Bamboo.ApiError) There was a problem sending the email through the <service_name> API.
+
+      Here is the response:
+
+      "<response>"
+
+      Here are the params we sent:
+
+      "<params>"
+
+      iex> raise_api_error(service_name, response, params, extra_message)
+      ** (Bamboo.ApiError) There was a problem sending the email through the <service_name> API.
+
+      Here is the response:
+
+      "<response>"
+
+      Here are the params we sent:
+
+      "<params>"
+
+      <extra_message>
+  """
   def raise_api_error(message), do: raise(__MODULE__, message: message)
   def raise_api_error(service_name, response, params, extra_message \\ "") do
     message = """
@@ -17,9 +51,13 @@ defmodule Bamboo.ApiError do
     Here are the params we sent:
 
     #{inspect params, limit: :infinity}
-    
-    #{extra_message}
     """
+
+    message =
+      case extra_message do
+        "" -> message
+        em -> message <> "\n#{em}\n"
+      end
 
     raise(__MODULE__, message: message)
   end

--- a/lib/bamboo/api_error.ex
+++ b/lib/bamboo/api_error.ex
@@ -1,0 +1,7 @@
+defmodule Bamboo.ApiError do
+  @moduledoc """
+  Error used to represent a problem when sending emails through an external email service API.
+  """
+
+  defexception [:message]
+end

--- a/lib/bamboo/api_error.ex
+++ b/lib/bamboo/api_error.ex
@@ -4,4 +4,31 @@ defmodule Bamboo.ApiError do
   """
 
   defexception [:message]
+
+  def raise_api_error(message), do: raise(__MODULE__, message: message)
+  def raise_api_error(adapter, response, params, extra_message \\ "") when is_atom(adapter) do
+    message = """
+    There was a problem sending the email through the #{adapter_name(adapter)} API.
+
+    Here is the response:
+
+    #{inspect response, limit: :infinity}
+
+    Here are the params we sent:
+
+    #{inspect params, limit: :infinity}
+    
+    #{extra_message}
+    """
+
+    raise(__MODULE__, message: message)
+  end
+
+  defp adapter_name(adapter) do
+    adapter
+    |> Atom.to_string
+    |> String.split(".")
+    |> List.last
+    |> String.replace_trailing("Adapter", "")
+  end
 end

--- a/lib/bamboo/api_error.ex
+++ b/lib/bamboo/api_error.ex
@@ -6,9 +6,9 @@ defmodule Bamboo.ApiError do
   defexception [:message]
 
   def raise_api_error(message), do: raise(__MODULE__, message: message)
-  def raise_api_error(adapter, response, params, extra_message \\ "") when is_atom(adapter) do
+  def raise_api_error(service_name, response, params, extra_message \\ "") do
     message = """
-    There was a problem sending the email through the #{adapter_name(adapter)} API.
+    There was a problem sending the email through the #{service_name} API.
 
     Here is the response:
 
@@ -22,13 +22,5 @@ defmodule Bamboo.ApiError do
     """
 
     raise(__MODULE__, message: message)
-  end
-
-  defp adapter_name(adapter) do
-    adapter
-    |> Atom.to_string
-    |> String.split(".")
-    |> List.last
-    |> String.replace_trailing("Adapter", "")
   end
 end

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -120,7 +120,7 @@ defmodule Bamboo.MailgunAdapterTest do
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 
-    assert_raise MailgunAdapter.ApiError, fn ->
+    assert_raise Bamboo.ApiError, fn ->
       email |> MailgunAdapter.deliver(@config)
     end
   end

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -166,7 +166,7 @@ defmodule Bamboo.MandrillAdapterTest do
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 
-    assert_raise Bamboo.MandrillAdapter.ApiError, fn ->
+    assert_raise Bamboo.ApiError, fn ->
       email |> MandrillAdapter.deliver(@config)
     end
   end
@@ -174,7 +174,7 @@ defmodule Bamboo.MandrillAdapterTest do
   test "removes api key from error output" do
     email = new_email(from: "INVALID_EMAIL")
 
-    assert_raise Bamboo.MandrillAdapter.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
+    assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
       email |> MandrillAdapter.deliver(@config)
     end
   end

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -157,7 +157,7 @@ defmodule Bamboo.SendGridAdapterTest do
     email = new_email(from: "INVALID_EMAIL")
 
     assert_raise Bamboo.ApiError, fn ->
-      email |> SendgridAdapter.deliver(@config)
+      email |> SendGridAdapter.deliver(@config)
     end
   end
 
@@ -165,7 +165,7 @@ defmodule Bamboo.SendGridAdapterTest do
     email = new_email(from: "INVALID_EMAIL")
 
     assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
-      email |> SendgridAdapter.deliver(@config)
+      email |> SendGridAdapter.deliver(@config)
     end
   end
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -156,16 +156,16 @@ defmodule Bamboo.SendGridAdapterTest do
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 
-    assert_raise Bamboo.SendGridAdapter.ApiError, fn ->
-      email |> SendGridAdapter.deliver(@config)
+    assert_raise Bamboo.ApiError, fn ->
+      email |> SendgridAdapter.deliver(@config)
     end
   end
 
   test "removes api key from error output" do
     email = new_email(from: "INVALID_EMAIL")
 
-    assert_raise Bamboo.SendGridAdapter.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
-      email |> SendGridAdapter.deliver(@config)
+    assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
+      email |> SendgridAdapter.deliver(@config)
     end
   end
 


### PR DESCRIPTION
This PR resolves #196.
- Removes specific api errors from adapters with external api calls
- Creates a common `Bamboo.ApiError` module
- Adds a `raise_api_error` function to every adapter with external api calls
