### PR TITLE
Print headers in email preview

### DIFF
--- a/lib/bamboo/plug/helper.ex
+++ b/lib/bamboo/plug/helper.ex
@@ -17,6 +17,12 @@ defmodule Bamboo.EmailPreviewPlug.Helper do
     |> Enum.join(", ")
   end
 
+  def format_headers(values) when is_binary(values), do: values
+  def format_headers(values) when is_list(values) do
+    Enum.join(values, ", ")
+  end
+  def format_headers(values), do: inspect(values)
+
   def format_text(nil), do: ""
   def format_text(text_body) do
     String.replace(text_body, "\n", "<br>")

--- a/lib/bamboo/plug/index.html.eex
+++ b/lib/bamboo/plug/index.html.eex
@@ -122,11 +122,13 @@
         font-weight: 700;
       }
 
-      .email-preview-recipients {
+      .email-preview-recipients,
+      .email-preview-headers {
         color: #aaa;
       }
 
-      .email-preview-recipients strong {
+      .email-preview-recipients strong,
+      .email-preview-headers strong {
         color: #555;
       }
 
@@ -158,6 +160,13 @@
           <span class="email-preview-recipients">
             From <strong><%= Bamboo.Email.get_address(@selected_email.from) %></strong>
             to <strong><%= Bamboo.EmailPreviewPlug.Helper.email_addresses(@selected_email) %></strong>
+          </span>
+          <span class="email-preview-headers">
+            <%= for {header, value} <- @selected_email.headers do %>
+              <div class="email-preview-header">
+                <%= header %> <strong><%= Bamboo.EmailPreviewPlug.Helper.format_headers(value) %></strong>
+              </div>
+            <% end %>
           </span>
         </section>
 


### PR DESCRIPTION
This PR prints the headers of the email to the preview.

I added this because I wanted to see things like "Reply-To" headers in the preview.

Is this something you'd be interested in?

Example:

![screen](https://cloud.githubusercontent.com/assets/379823/19723412/7ccdf070-9b7b-11e6-9dd1-d312671d0079.png)
