### PR TITLE
Fixed parentheses deprecations for elixir 1.4

### DIFF
--- a/lib/bamboo/adapters/sendgrid_adapter.ex
+++ b/lib/bamboo/adapters/sendgrid_adapter.ex
@@ -61,7 +61,7 @@ defmodule Bamboo.SendgridAdapter do
   def deliver(email, config) do
     api_key = get_key(config)
     body = email |> to_sendgrid_body |> Plug.Conn.Query.encode
-    url = [base_uri, @send_message_path]
+    url = [base_uri(), @send_message_path]
 
     case :hackney.post(url, headers(api_key), body, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -22,7 +22,7 @@ defmodule Bamboo.TestAdapter do
   @doc false
   def deliver(email, _config) do
     email = clean_assigns(email)
-    send test_process, {:delivered_email, email}
+    send test_process(), {:delivered_email, email}
   end
 
   defp test_process do

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -65,13 +65,13 @@ defmodule Bamboo.Mailer do
 
       @spec deliver_now(Bamboo.Email.t) :: Bamboo.Email.t
       def deliver_now(email) do
-        config = build_config
+        config = build_config()
         Bamboo.Mailer.deliver_now(config.adapter, email, config)
       end
 
       @spec deliver_later(Bamboo.Email.t) :: Bamboo.Email.t
       def deliver_later(email) do
-        config = build_config
+        config = build_config()
         Bamboo.Mailer.deliver_later(config.adapter, email, config)
       end
 

--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -102,7 +102,7 @@ defmodule Bamboo.Phoenix do
   import Bamboo.Email, only: [put_private: 3]
 
   defmacro __using__(view: view_module) do
-    verify_phoenix_dep
+    verify_phoenix_dep()
     quote do
       import Bamboo.Email
       import Bamboo.Phoenix, except: [render: 3]

--- a/lib/bamboo/plug/email_preview_plug.ex
+++ b/lib/bamboo/plug/email_preview_plug.ex
@@ -35,16 +35,16 @@ defmodule Bamboo.EmailPreviewPlug do
   plug :dispatch
 
   get "/" do
-    if Enum.empty?(all_emails) do
+    if Enum.empty?(all_emails()) do
       conn |> render(:ok, "no_emails.html")
     else
-      conn |> render(:ok, "index.html", emails: all_emails, selected_email: newest_email)
+      conn |> render(:ok, "index.html", emails: all_emails(), selected_email: newest_email())
     end
   end
 
   get "/:id" do
     if email = SentEmail.get(id) do
-      conn |> render(:ok, "index.html", emails: all_emails, selected_email: email)
+      conn |> render(:ok, "index.html", emails: all_emails(), selected_email: email)
     else
       conn |> render(:not_found, "email_not_found.html")
     end
@@ -67,7 +67,7 @@ defmodule Bamboo.EmailPreviewPlug do
   end
 
   defp newest_email do
-    all_emails |> List.first
+    all_emails() |> List.first
   end
 
   defp render(conn, status, template_name, assigns \\ []) do

--- a/lib/bamboo/sent_email.ex
+++ b/lib/bamboo/sent_email.ex
@@ -88,7 +88,7 @@ defmodule Bamboo.SentEmail do
   end
 
   defp do_get(id) do
-    Enum.find all, nil, fn(email) ->
+    Enum.find all(), nil, fn(email) ->
       email |> get_id |> String.downcase == String.downcase(id)
     end
   end
@@ -113,7 +113,7 @@ defmodule Bamboo.SentEmail do
   end
 
   defp put_rand_id(email) do
-    email |> Bamboo.Email.put_private(:local_adapter_id, rand_id)
+    email |> Bamboo.Email.put_private(:local_adapter_id, rand_id())
   end
 
   defp rand_id do
@@ -129,7 +129,7 @@ defmodule Bamboo.SentEmail do
   there are 2 or more emails.
   """
   def one do
-    case all do
+    case all() do
       [email] -> email
       [] -> raise NoDeliveriesError
       emails -> raise DeliveriesError, emails

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -20,7 +20,7 @@ defmodule Bamboo.TaskSupervisorStrategy do
 
   @doc false
   def deliver_later(adapter, email, config) do
-    Task.Supervisor.start_child supervisor_name, fn ->
+    Task.Supervisor.start_child supervisor_name(), fn ->
       adapter.deliver(email, config)
     end
   end

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -195,8 +195,8 @@ defmodule Bamboo.Test do
 
   @doc false
   def flunk_with_email_list(email) do
-    if Enum.empty?(delivered_emails) do
-      flunk_no_emails_received
+    if Enum.empty?(delivered_emails()) do
+      flunk_no_emails_received()
     else
       flunk """
       There were no matching emails.
@@ -207,7 +207,7 @@ defmodule Bamboo.Test do
 
       Delivered emails:
 
-      #{delivered_emails_as_list}
+      #{delivered_emails_as_list()}
       """
     end
   end
@@ -244,7 +244,7 @@ defmodule Bamboo.Test do
   end
 
   defp delivered_emails do
-    {:messages, messages} = Process.info(self, :messages)
+    {:messages, messages} = Process.info(self(), :messages)
 
     for {:delivered_email, _} = email_message <- messages do
       email_message
@@ -252,7 +252,7 @@ defmodule Bamboo.Test do
   end
 
   defp delivered_emails_as_list do
-    delivered_emails |> add_asterisk |> Enum.join("\n")
+    delivered_emails() |> add_asterisk |> Enum.join("\n")
   end
 
   defp add_asterisk(emails) do
@@ -276,7 +276,7 @@ defmodule Bamboo.Test do
     receive do
       {:delivered_email, email} -> flunk_with_unexpected_email(email)
     after
-      refute_timeout -> true
+      refute_timeout() -> true
     end
   end
 
@@ -317,7 +317,7 @@ defmodule Bamboo.Test do
     receive do
       {:delivered_email, ^email} -> flunk_with_unexpected_matching_email(email)
     after
-      refute_timeout -> true
+      refute_timeout() -> true
     end
   end
 
@@ -332,7 +332,7 @@ defmodule Bamboo.Test do
   end
 
   defp refute_timeout do
-    if using_shared_mode? do
+    if using_shared_mode?() do
       Application.get_env(:bamboo, :refute_timeout) || raise """
       When using shared mode with Bamboo.Test, you must set a timeout. This
       is because an email can be delivered after the assertion is called.

--- a/lib/mix/start_email_preview_task.ex
+++ b/lib/mix/start_email_preview_task.ex
@@ -40,11 +40,11 @@ defmodule Mix.Tasks.Bamboo.StartEmailPreview do
     end
 
     IO.puts "Running email preview on port 4003"
-    no_halt
+    no_halt()
   end
 
   defp no_halt do
-    unless iex_running?, do: :timer.sleep(:infinity)
+    unless iex_running?(), do: :timer.sleep(:infinity)
   end
 
   defp iex_running? do

--- a/mix.exs
+++ b/mix.exs
@@ -17,9 +17,9 @@ defmodule Bamboo.Mixfile do
      " Works with Mandrill, Mailgun, SendGrid, SparkPost, Postmark, in-memory, and test.",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
+     package: package(),
      docs: [main: "readme", extras: ["README.md"]],
-     deps: deps]
+     deps: deps()]
   end
 
   defp compilers(:test), do: [:phoenix] ++ Mix.compilers
@@ -43,8 +43,8 @@ defmodule Bamboo.Mixfile do
     ]
   end
 
-  defp elixirc_paths(:test), do: elixirc_paths ++ ["test/support"]
-  defp elixirc_paths(_), do: elixirc_paths
+  defp elixirc_paths(:test), do: elixirc_paths() ++ ["test/support"]
+  defp elixirc_paths(_), do: elixirc_paths()
   defp elixirc_paths, do: ["lib"]
 
   defp deps do

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -4,8 +4,6 @@ defmodule Bamboo.MailgunAdapterTest do
   alias Bamboo.MailgunAdapter
 
   @config %{adapter: MailgunAdapter, api_key: "dummyapikey", domain: "test.tt"}
-  @config_with_bad_key %{@config | api_key: nil}
-  @config_with_bad_domain %{@config | domain: nil}
 
   defmodule FakeMailgun do
     use Plug.Router
@@ -20,7 +18,7 @@ defmodule Bamboo.MailgunAdapterTest do
     def start_server(parent) do
       Agent.start_link(fn -> Map.new end, name: __MODULE__)
       Agent.update(__MODULE__, &Map.put(&1, :parent, parent))
-      port = get_free_port
+      port = get_free_port()
       Application.put_env(:bamboo, :mailgun_base_uri, "http://localhost:#{port}/")
       Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
     end
@@ -51,7 +49,7 @@ defmodule Bamboo.MailgunAdapterTest do
   end
 
   setup do
-    FakeMailgun.start_server(self)
+    FakeMailgun.start_server(self())
 
     on_exit fn ->
       FakeMailgun.shutdown
@@ -73,7 +71,7 @@ defmodule Bamboo.MailgunAdapterTest do
   end
 
   test "deliver/2 sends the to the right url" do
-    new_email |> MailgunAdapter.deliver(@config)
+    new_email() |> MailgunAdapter.deliver(@config)
 
     assert_receive {:fake_mailgun, %{request_path: request_path}}
 

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -20,7 +20,7 @@ defmodule Bamboo.MandrillAdapterTest do
     def start_server(parent) do
       Agent.start_link(fn -> HashDict.new end, name: __MODULE__)
       Agent.update(__MODULE__, &HashDict.put(&1, :parent, parent))
-      port = get_free_port
+      port = get_free_port()
       Application.put_env(:bamboo, :mandrill_base_uri, "http://localhost:#{port}")
       Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
     end
@@ -58,7 +58,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   setup do
-    FakeMandrill.start_server(self)
+    FakeMandrill.start_server(self())
 
     on_exit fn ->
       FakeMandrill.shutdown
@@ -78,7 +78,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   test "deliver/2 sends the to the right url" do
-    new_email |> MandrillAdapter.deliver(@config)
+    new_email() |> MandrillAdapter.deliver(@config)
 
     assert_receive {:fake_mandrill, %{request_path: request_path}}
 
@@ -86,7 +86,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   test "deliver/2 sends the to the right url for templates" do
-    new_email |> MandrillHelper.template("hello") |> MandrillAdapter.deliver(@config)
+    new_email() |> MandrillHelper.template("hello") |> MandrillAdapter.deliver(@config)
 
     assert_receive {:fake_mandrill, %{request_path: request_path}}
 
@@ -133,7 +133,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   test "deliver/2 adds extra params to the message " do
-    email = new_email |> MandrillHelper.put_param("important", true)
+    email = new_email() |> MandrillHelper.put_param("important", true)
 
     email |> MandrillAdapter.deliver(@config)
 
@@ -142,7 +142,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   test "deliver/2 puts template name and empty content" do
-    email = new_email |> MandrillHelper.template("hello")
+    email = new_email() |> MandrillHelper.template("hello")
 
     email |> MandrillAdapter.deliver(@config)
 
@@ -152,7 +152,7 @@ defmodule Bamboo.MandrillAdapterTest do
   end
 
   test "deliver/2 puts template name and content" do
-    email = new_email |> MandrillHelper.template("hello", [
+    email = new_email() |> MandrillHelper.template("hello", [
       %{name: 'example name', content: 'example content'}
     ])
 

--- a/test/lib/bamboo/adapters/mandrill_helper_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_helper_test.exs
@@ -4,7 +4,7 @@ defmodule Bamboo.MandrillHelperTest do
   alias Bamboo.MandrillHelper
 
   test "put_param/3 puts a map in private.message_params" do
-    email = new_email |> MandrillHelper.put_param("track_links", true)
+    email = new_email() |> MandrillHelper.put_param("track_links", true)
 
     assert email.private.message_params == %{"track_links" => true}
   end
@@ -21,7 +21,7 @@ defmodule Bamboo.MandrillHelperTest do
       }
     ]
 
-    email = MandrillHelper.put_merge_vars new_email, users, fn(user) ->
+    email = MandrillHelper.put_merge_vars new_email(), users, fn(user) ->
       %{full_name: user.full_name}
     end
 
@@ -49,18 +49,18 @@ defmodule Bamboo.MandrillHelperTest do
   end
 
   test "adds tags to mandrill emails" do
-    email = new_email |> MandrillHelper.tag("welcome-email")
+    email = new_email() |> MandrillHelper.tag("welcome-email")
     assert email.private.message_params == %{"tags" => ["welcome-email"]}
 
-    email = new_email |> MandrillHelper.tag(["welcome-email", "awesome"])
+    email = new_email() |> MandrillHelper.tag(["welcome-email", "awesome"])
     assert email.private.message_params == %{"tags" => ["welcome-email", "awesome"]}
   end
 
   test "adds template information to mandrill emails" do
-    email = new_email |> MandrillHelper.template("welcome", [%{"name" => "example_name", "content" => "example_content"}])
+    email = new_email() |> MandrillHelper.template("welcome", [%{"name" => "example_name", "content" => "example_content"}])
     assert email.private == %{template_name: "welcome", template_content: [%{"name" => "example_name", "content" => "example_content"}]}
 
-    email = new_email |> MandrillHelper.template("welcome")
+    email = new_email() |> MandrillHelper.template("welcome")
     assert email.private == %{template_name: "welcome", template_content: []}
   end
 end

--- a/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
@@ -19,7 +19,7 @@ defmodule Bamboo.SendgridAdapterTest do
     def start_server(parent) do
       Agent.start_link(fn -> HashDict.new end, name: __MODULE__)
       Agent.update(__MODULE__, &HashDict.put(&1, :parent, parent))
-      port = get_free_port
+      port = get_free_port()
       Application.put_env(:bamboo, :sendgrid_base_uri, "http://localhost:#{port}")
       Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
     end
@@ -50,7 +50,7 @@ defmodule Bamboo.SendgridAdapterTest do
   end
 
   setup do
-    FakeSendgrid.start_server(self)
+    FakeSendgrid.start_server(self())
 
     on_exit fn ->
       FakeSendgrid.shutdown
@@ -70,7 +70,7 @@ defmodule Bamboo.SendgridAdapterTest do
   end
 
   test "deliver/2 sends the to the right url" do
-    new_email |> SendgridAdapter.deliver(@config)
+    new_email() |> SendgridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{request_path: request_path}}
 

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -6,7 +6,7 @@ defmodule Bamboo.SendgridHelperTest do
   @template_id "80509523-83de-42b6-a2bf-54b7513bd2aa"
 
   setup do
-    {:ok, email: Bamboo.Email.new_email}
+    {:ok, email: Bamboo.Email.new_email()}
   end
 
   test "with_template/2 adds the correct template", %{email: email} do

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -76,14 +76,14 @@ defmodule Bamboo.TestAdapterTest do
 
   test "assert_no_emails_delivered raises helpful error message" do
     assert_raise RuntimeError, ~r/has been renamed/, fn ->
-      assert_no_emails_sent
+      assert_no_emails_sent()
     end
   end
 
   test "assert_delivered_email shows non-matching delivered emails" do
     sent_email = new_email(from: "foo@bar.com", to: ["foo@bar.com"])
 
-    sent_email |> TestMailer.deliver_now
+    sent_email |> TestMailer.deliver_now()
 
     try do
       assert_delivered_email %{sent_email | to: "oops"}
@@ -101,7 +101,7 @@ defmodule Bamboo.TestAdapterTest do
 
     TestMailer.deliver_now(sent_email)
 
-    send self, :not_an_email
+    send self(), :not_an_email
 
     try do
       assert_delivered_email %{sent_email | to: "oops"}
@@ -147,7 +147,7 @@ defmodule Bamboo.TestAdapterTest do
     TestMailer.deliver_now(sent_email)
 
     try do
-      assert_no_emails_delivered
+      assert_no_emails_delivered()
     rescue
       error in [ExUnit.AssertionError] ->
         assert error.message =~ "Unexpectedly delivered an email"
@@ -174,13 +174,13 @@ defmodule Bamboo.TestAdapterTest do
   end
 
   test "assert_no_emails_delivered" do
-    assert_no_emails_delivered
+    assert_no_emails_delivered()
 
     sent_email = new_email(from: "foo@bar.com", to: "whoever")
     sent_email |> TestMailer.deliver_now
 
     assert_raise ExUnit.AssertionError, fn ->
-      assert_no_emails_delivered
+      assert_no_emails_delivered()
     end
   end
 

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -4,7 +4,7 @@ defmodule Bamboo.EmailTest do
   import Bamboo.Email
 
   test "new_email/1 returns an Email struct" do
-    assert new_email == %Bamboo.Email{
+    assert new_email() == %Bamboo.Email{
       from: nil,
       to: nil,
       cc: nil,
@@ -55,7 +55,7 @@ defmodule Bamboo.EmailTest do
   end
 
   test "can pipe updates with functions" do
-    email = new_email
+    email = new_email()
       |> from("me@foo.com")
       |> to("to@example.com")
       |> cc("cc@example.com")
@@ -72,7 +72,7 @@ defmodule Bamboo.EmailTest do
   end
 
   test "put_private/3 puts a key and value in the private attribute" do
-    email = new_email |> put_private("foo", "bar")
+    email = new_email() |> put_private("foo", "bar")
 
     assert email.private["foo"] == "bar"
   end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -37,7 +37,7 @@ defmodule Bamboo.MailerTest do
   end
 
   setup do
-    Process.register(self, :mailer_test)
+    Process.register(self(), :mailer_test)
     :ok
   end
 
@@ -88,35 +88,35 @@ defmodule Bamboo.MailerTest do
   end
 
   test "deliver_now/1 with empty lists for recipients does not deliver email" do
-    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_now
+    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_now()
     refute_received {:deliver, _, _}
 
-    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_now
+    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_now()
     refute_received {:deliver, _, _}
 
-    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_now
+    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_now()
     refute_received {:deliver, _, _}
 
-    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_now
+    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_now()
     refute_received {:deliver, _, _}
   end
 
   test "deliver_later/1 with empty lists for recipients does not deliver email" do
-    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_later
+    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_later()
     refute_received {:deliver, _, _}
 
-    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_later
+    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_later()
     refute_received {:deliver, _, _}
 
-    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_later
+    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_later()
     refute_received {:deliver, _, _}
 
-    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_later
+    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_later()
     refute_received {:deliver, _, _}
   end
 
   test "deliver_later/1 calls deliver on the adapter" do
-    email = new_email
+    email = new_email()
 
     FooMailer.deliver_later(email)
 
@@ -174,22 +174,22 @@ defmodule Bamboo.MailerTest do
 
   test "raises if all receipients are nil" do
     assert_raise Bamboo.NilRecipientsError, fn ->
-      new_email(to: nil, cc: nil, bcc: nil) |> FooMailer.deliver_now
+      new_email(to: nil, cc: nil, bcc: nil) |> FooMailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: {"foo", nil})
-      |> FooMailer.deliver_now
+      |> FooMailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: [{"foo", nil}])
-      |> FooMailer.deliver_now
+      |> FooMailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: [nil])
-      |> FooMailer.deliver_now
+      |> FooMailer.deliver_now()
     end
   end
 

--- a/test/lib/bamboo/multi_process_test.exs
+++ b/test/lib/bamboo/multi_process_test.exs
@@ -31,7 +31,7 @@ defmodule Bamboo.MultiProcessTest do
 
   test "assert_no_emails_delivered with shared mode and with refute_timeout blank, raises an error" do
     assert_raise RuntimeError, ~r/set a timeout/, fn ->
-      assert_no_emails_delivered
+      assert_no_emails_delivered()
     end
   end
 end

--- a/test/lib/bamboo/phoenix_test.exs
+++ b/test/lib/bamboo/phoenix_test.exs
@@ -35,22 +35,22 @@ defmodule Bamboo.PhoenixTest do
     end
 
     def html_email do
-      new_email
+      new_email()
       |> render("html_email.html")
     end
 
     def text_email do
-      new_email
+      new_email()
       |> render("text_email.text")
     end
 
     def no_template do
-      new_email
+      new_email()
       |> render(:non_existent)
     end
 
     def invalid_template do
-      new_email
+      new_email()
       |> render("template.foobar")
     end
   end

--- a/test/lib/bamboo/plug/email_preview_plug_test.exs
+++ b/test/lib/bamboo/plug/email_preview_plug_test.exs
@@ -26,9 +26,9 @@ defmodule Bamboo.EmailPreviewTest do
     conn = AppRouter.call(conn, nil)
 
     assert conn.status == 200
-    assert selected_sidebar_email_text(conn) =~ newest_email.subject
-    assert showing_in_preview_pane?(conn, newest_email)
-    refute showing_in_preview_pane?(conn, oldest_email)
+    assert selected_sidebar_email_text(conn) =~ newest_email().subject
+    assert showing_in_preview_pane?(conn, newest_email())
+    refute showing_in_preview_pane?(conn, oldest_email())
     for email <- emails do
       assert Floki.raw_html(sidebar(conn)) =~ ~s(href="/sent_emails/foo/#{SentEmail.get_id(email)}")
       assert Floki.text(sidebar(conn)) =~ email.subject

--- a/test/lib/bamboo/sent_email_test.exs
+++ b/test/lib/bamboo/sent_email_test.exs
@@ -10,7 +10,7 @@ defmodule Bamboo.SentEmailTest do
   end
 
   test "get_id gets the emails id" do
-    email = new_email |> put_private(:local_adapter_id, 1)
+    email = new_email() |> put_private(:local_adapter_id, 1)
 
     assert SentEmail.get_id(email) == 1
   end
@@ -22,7 +22,7 @@ defmodule Bamboo.SentEmailTest do
   end
 
   test "raises helpful message if the id is not set" do
-    email = new_email
+    email = new_email()
 
     assert_raise RuntimeError, ~r/no id was present/, fn ->
       SentEmail.get_id(email)
@@ -75,8 +75,8 @@ defmodule Bamboo.SentEmailTest do
   end
 
   test "one/0 raises if there are 2 or more emails in the mailbox" do
-    SentEmail.push(new_email)
-    SentEmail.push(new_email)
+    SentEmail.push(new_email())
+    SentEmail.push(new_email())
 
     assert_raise SentEmail.DeliveriesError, fn ->
       SentEmail.one
@@ -97,7 +97,7 @@ defmodule Bamboo.SentEmailTest do
   end
 
   test "reset/0 removes all emails from the mailbox" do
-    SentEmail.push(new_email)
+    SentEmail.push(new_email())
 
     SentEmail.reset
 

--- a/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
+++ b/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
@@ -10,7 +10,7 @@ defmodule Bamboo.TaskSupervisorStrategyTest do
   @mailer_config %{}
 
   test "deliver_later delivers the email" do
-    Process.register(self, :task_supervisor_strategy_test)
+    Process.register(self(), :task_supervisor_strategy_test)
 
     Bamboo.TaskSupervisorStrategy.deliver_later(
       FakeAdapter,


### PR DESCRIPTION
Elixir 1.4 just released lately :tada:

The parentheses are now recommended for method calls without arguments.

This PR fixes the parts where we had deprecations at various areas like so... (See attached code)

Thanks!

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:20

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:22

warning: variable "elixirc_paths" does not exist and is being expanded to "elixirc_paths()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:46

warning: variable "elixirc_paths" does not exist and is being expanded to "elixirc_paths()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:47

warning: variable "all_emails" does not exist and is being expanded to "all_emails()", please use parenth
eses to remove the ambiguity or change the variable name
  lib/bamboo/plug/email_preview_plug.ex:38

warning: variable "all_emails" does not exist and is being expanded to "all_emails()", please use parenth
eses to remove the ambiguity or change the variable name
  lib/bamboo/plug/email_preview_plug.ex:41

warning: variable "newest_email" does not exist and is being expanded to "newest_email()", please use par
entheses to remove the ambiguity or change the variable name
  lib/bamboo/plug/email_preview_plug.ex:41

warning: variable "all_emails" does not exist and is being expanded to "all_emails()", please use parenth
eses to remove the ambiguity or change the variable name
  lib/bamboo/plug/email_preview_plug.ex:47

warning: variable "all_emails" does not exist and is being expanded to "all_emails()", please use parenth
eses to remove the ambiguity or change the variable name
  lib/bamboo/plug/email_preview_plug.ex:70

warning: variable "test_process" does not exist and is being expanded to "test_process()", please use par
entheses to remove the ambiguity or change the variable name
  lib/bamboo/adapters/test_adapter.ex:25

warning: variable "verify_phoenix_dep" does not exist and is being expanded to "verify_phoenix_dep()", pl
ease use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/phoenix.ex:105

warning: variable "base_uri" does not exist and is being expanded to "base_uri()", please use parentheses
 to remove the ambiguity or change the variable name
  lib/bamboo/adapters/sendgrid_adapter.ex:64

warning: variable "supervisor_name" does not exist and is being expanded to "supervisor_name()", please u
se parentheses to remove the ambiguity or change the variable name
  lib/bamboo/strategies/task_supervisor_strategy.ex:23

warning: variable "no_halt" does not exist and is being expanded to "no_halt()", please use parentheses t
o remove the ambiguity or change the variable name
  lib/mix/start_email_preview_task.ex:43

warning: variable "iex_running?" does not exist and is being expanded to "iex_running?()", please use parentheses to remove the ambiguity or change the variable name
  lib/mix/start_email_preview_task.ex:47

warning: variable "delivered_emails" does not exist and is being expanded to "delivered_emails()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:198

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/sent_email.ex:91

warning: variable "delivered_emails_as_list" does not exist and is being expanded to "delivered_emails_as_list()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:210

warning: variable "flunk_no_emails_received" does not exist and is being expanded to "flunk_no_emails_received()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:199

warning: variable "rand_id" does not exist and is being expanded to "rand_id()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/sent_email.ex:116

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:247

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/sent_email.ex:132

warning: variable "delivered_emails" does not exist and is being expanded to "delivered_emails()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:255

warning: variable "refute_timeout" does not exist and is being expanded to "refute_timeout()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:279

warning: variable "refute_timeout" does not exist and is being expanded to "refute_timeout()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:320

warning: variable "using_shared_mode?" does not exist and is being expanded to "using_shared_mode?()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/test.ex:335

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/sent_email_test.exs:79

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/sent_email_test.exs:100

warning: variable "newest_email" does not exist and is being expanded to "newest_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/plug/email_preview_plug_test.exs:29

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/phoenix_test.exs:38

warning: variable "newest_email" does not exist and is being expanded to "newest_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/plug/email_preview_plug_test.exs:30

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/phoenix_test.exs:43

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/phoenix_test.exs:48

warning: variable "oldest_email" does not exist and is being expanded to "oldest_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/plug/email_preview_plug_test.exs:31

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/phoenix_test.exs:53

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/strategies/task_supervisor_strategy_test.exs:13
warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_adapter_test.exs:155

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remo
ve the ambiguity or change the variable name
  test/lib/bamboo/adapters/sendgrid_adapter_test.exs:53

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/sendgrid_adapter_test.exs:73

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/email_test.exs:7

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/email_test.exs:58

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/email_test.exs:75

warning: variable "build_config" does not exist and is being expanded to "build_config()", please use par
entheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:16

warning: variable "build_config" does not exist and is being expanded to "build_config()", please use par
entheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:16

warning: variable "assert_no_emails_sent" does not exist and is being expanded to "assert_no_emails_sent(
)", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:79

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remo
ve the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:104

warning: variable "assert_no_emails_delivered" does not exist and is being expanded to "assert_no_emails_
delivered()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:150

warning: variable "assert_no_emails_delivered" does not exist and is being expanded to "assert_no_emails_
delivered()", please use parentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/test_adapter_test.exs:177

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:7

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthes
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:24

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthe$
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:52

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthe$
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:55

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthe$
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:60

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthe$
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mandrill_helper_test.exs:63

warning: variable "get_free_port" does not exist and is being expanded to "get_free_port()", please use $
arentheses to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mailgun_adapter_test.exs:23

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to rem$
ve the ambiguity or change the variable name
  test/lib/bamboo/adapters/mailgun_adapter_test.exs:54

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parenthe$
es to remove the ambiguity or change the variable name
  test/lib/bamboo/adapters/mailgun_adapter_test.exs:76
```