### PR TITLE
Fix HashDict deprecations for Map (elixir 1.4)

### DIFF
--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -18,8 +18,8 @@ defmodule Bamboo.MandrillAdapterTest do
     plug :dispatch
 
     def start_server(parent) do
-      Agent.start_link(fn -> HashDict.new end, name: __MODULE__)
-      Agent.update(__MODULE__, &HashDict.put(&1, :parent, parent))
+      Agent.start_link(fn -> Map.new end, name: __MODULE__)
+      Agent.update(__MODULE__, &Map.put(&1, :parent, parent))
       port = get_free_port
       Application.put_env(:bamboo, :mandrill_base_uri, "http://localhost:#{port}")
       Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
@@ -51,7 +51,7 @@ defmodule Bamboo.MandrillAdapterTest do
     end
 
     defp send_to_parent(conn) do
-      parent = Agent.get(__MODULE__, fn(set) -> HashDict.get(set, :parent) end)
+      parent = Agent.get(__MODULE__, fn(set) -> Map.get(set, :parent) end)
       send parent, {:fake_mandrill, conn}
       conn
     end

--- a/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_adapter_test.exs
@@ -17,8 +17,8 @@ defmodule Bamboo.SendgridAdapterTest do
     plug :dispatch
 
     def start_server(parent) do
-      Agent.start_link(fn -> HashDict.new end, name: __MODULE__)
-      Agent.update(__MODULE__, &HashDict.put(&1, :parent, parent))
+      Agent.start_link(fn -> Map.new end, name: __MODULE__)
+      Agent.update(__MODULE__, &Map.put(&1, :parent, parent))
       port = get_free_port
       Application.put_env(:bamboo, :sendgrid_base_uri, "http://localhost:#{port}")
       Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
@@ -43,7 +43,7 @@ defmodule Bamboo.SendgridAdapterTest do
     end
 
     defp send_to_parent(conn) do
-      parent = Agent.get(__MODULE__, fn(set) -> HashDict.get(set, :parent) end)
+      parent = Agent.get(__MODULE__, fn(set) -> Map.get(set, :parent) end)
       send parent, {:fake_sendgrid, conn}
       conn
     end


### PR DESCRIPTION
This PR removes the deprecations for HashDict Usage in favor of Map.

HashDict has been deprecated since Elixir 1.2 as Erlang 1.8 got a huge performance boost on maps.

Map is now the favored data structure for maps.

See :

https://github.com/elixir-lang/elixir/blob/v1.2.0/CHANGELOG.md#erlang-18-support
https://hexdocs.pm/elixir/Map.html

Thanks!
