### PR TITLE
Remove redundant phoenix checks

### DIFF
--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -264,34 +264,24 @@ defmodule Bamboo.Phoenix do
     end
   end
 
-  if Code.ensure_loaded?(Phoenix.View) do
-    defp render_html(email, template) do
-      # Phoenix uses the assigns.layout to determine what layout to use
-      assigns = Map.put(email.assigns, :layout, email.private.html_layout)
+  defp render_html(email, template) do
+    # Phoenix uses the assigns.layout to determine what layout to use
+    assigns = Map.put(email.assigns, :layout, email.private.html_layout)
 
-      Phoenix.View.render_to_string(
-        email.private.view_module,
-        template,
-        assigns
-      )
-    end
+    Phoenix.View.render_to_string(
+    email.private.view_module,
+    template,
+    assigns
+    )
+  end
 
-    defp render_text(email, template) do
-      assigns = Map.put(email.assigns, :layout, email.private.text_layout)
+  defp render_text(email, template) do
+    assigns = Map.put(email.assigns, :layout, email.private.text_layout)
 
-      Phoenix.View.render_to_string(
-        email.private.view_module,
-        template,
-        assigns
-      )
-    end
-  else
-    defp render_html(_email, _template), do: raise_phoenix_required()
-
-    defp render_text(_email, _template), do: raise_phoenix_required()
-
-    defp raise_phoenix_required do
-      raise "phoenix is required to render views with Bamboo.Phoenix"
-    end
+    Phoenix.View.render_to_string(
+    email.private.view_module,
+    template,
+    assigns
+    )
   end
 end


### PR DESCRIPTION
We already verify the phoenix dependency when you use Bamboo.Phoenix
with Bamboo.Phoenix.verify_phoenix_dep

The other checks were redundant and caused some issues with compiling.

Closes #236