### PR TITLE
Initial attempt at supporting different matchers

### DIFF
--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -188,9 +188,19 @@ defmodule Bamboo.Test do
       assert_receive({:delivered_email, email}, 100, Bamboo.Test.flunk_no_emails_received)
 
       recieved_email_params = email |> Map.from_struct
-      assert Enum.all?(email_params, fn({k, v}) -> recieved_email_params[k] == v end),
-        Bamboo.Test.flunk_attributes_do_not_match(email_params, recieved_email_params) 
+      assert Enum.all?(email_params, fn({k, v}) -> do_match(recieved_email_params[k], v) end),
+        Bamboo.Test.flunk_attributes_do_not_match(email_params, recieved_email_params)
     end
+  end
+
+  @doc false
+  def do_match(value1, value2 = %Regex{}) do
+    Regex.match?(value2, value1)
+  end
+
+  @doc false
+  def do_match(value1, value2) do
+    value1 == value2
   end
 
   @doc false

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -148,6 +148,20 @@ defmodule Bamboo.TestAdapterTest do
     assert_delivered_with text_body: ~r/like/
   end
 
+  test "ensure assert_delivered_with regex matching doesn't provide a false positive" do
+    new_email(to: {nil, "foo@bar.com"}, from: {nil, "foo@bar.com"}, text_body: "I really like coffee")
+      |> TestMailer.deliver_now
+
+    try do
+      assert_delivered_with text_body: ~r/tea/
+    rescue
+      error in [ExUnit.AssertionError] ->
+          assert error.message =~ "do not match"
+    else
+        _ -> flunk "assert_delivered_with should have failed"
+    end
+  end
+
   test "assert_no_emails_delivered shows the delivered email" do
     sent_email = new_email(from: "foo@bar.com", to: ["foo@bar.com"])
 

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -141,6 +141,13 @@ defmodule Bamboo.TestAdapterTest do
     end
   end
 
+  test "assert_delivered_with allows regex matching" do
+    new_email(to: {nil, "foo@bar.com"}, from: {nil, "foo@bar.com"}, text_body: "I really like coffee")
+      |> TestMailer.deliver_now
+
+    assert_delivered_with text_body: ~r/like/
+  end
+
   test "assert_no_emails_delivered shows the delivered email" do
     sent_email = new_email(from: "foo@bar.com", to: ["foo@bar.com"])
 


### PR DESCRIPTION
Signed-off-by: David McKay <david@rawkode.com>

I don't believe this is optimal, I'm really looking for some guidance.

I believe `do_match` should be `defp`, but I don't know if that is possible because `assert_delivered_with` is a macro