### PR TITLE
Rename EmailPreviewPlug to SentEmailViwerPlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Flexible and easy to use email for Elixir.
 * **Very composable**. Emails are just a Bamboo.Email struct and can be manipulated with plain functions.
 * **Easy to unit test**. Because delivery is separated from email creation, no special functions are needed, just assert against fields on the email.
 * **Easy to test delivery in integration tests**. Helpers are provided to make testing easy and robust.
-* **Preview sent emails during development**. Bamboo comes with a plug that can be used in your router to preview sent emails.
+* **View sent emails during development**. Bamboo comes with a plug that can be used in your router to view sent emails.
 
 See the [docs] for the most up to date information.
 
@@ -192,17 +192,17 @@ Phoenix is not required to use Bamboo. However, if you do use Phoenix, you can
 use Phoenix views and layouts with Bamboo. See
 [Bamboo.Phoenix](https://hexdocs.pm/bamboo/Bamboo.Phoenix.html)
 
-## Previewing Sent Emails
+## Viewing Sent Emails
 
 Bamboo comes with a handy plug for viewing emails sent in development. Now you
 don't have to look at the logs to get password resets, confirmation links, etc.
-Just open up the email preview and click the link.
+Just open up the sent email viewer and click the link.
 
-See [Bamboo.EmailPreviewPlug](https://hexdocs.pm/bamboo/Bamboo.EmailPreviewPlug.html)
+See [Bamboo.SentEmailViewerPlug](https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html)
 
 Here is what it looks like:
 
-![Screenshot of BambooEmailPreview](https://cloud.githubusercontent.com/assets/22394/14929083/bda60b76-0e29-11e6-9e11-5ec60069e825.png)
+![Screenshot of BambooSentEmailViewer](https://cloud.githubusercontent.com/assets/22394/14929083/bda60b76-0e29-11e6-9e11-5ec60069e825.png)
 
 ## Mandrill Specific Functionality (tags, merge vars, templates, etc.)
 

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,5 @@
 {
   "skip_files": [
-    "lib/mix/start_email_preview_task.ex",
+    "lib/mix/start_sent_email_viewer_task.ex"
   ]
 }

--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -7,7 +7,7 @@ defmodule Bamboo.LocalAdapter do
   Typically this adapter is used in the dev environment so emails are not
   delivered to real email addresses.
 
-  You can use this adapter along with `Bamboo.EmailPreviewPlug` to view emails
+  You can use this adapter along with `Bamboo.SentEmailViewerPlug` to view emails
   in the browser.
 
   ## Example config

--- a/lib/bamboo/plug/sent_email_viewer/email_not_found.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/email_not_found.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>Email Preview</title>
+    <title>Sent Emails</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
       html {
@@ -24,13 +24,9 @@
         width: 80%;
         max-width: 500px;
         padding: 40px 50px;
+        text-align: center;
         background-color: #f8f8f8;
         border-radius: 12px;
-      }
-
-      .main-message {
-        text-align: center;
-        margin-bottom: 40px;
       }
 
       h1 {
@@ -38,30 +34,20 @@
         font-size: 18px;
       }
 
-      li {
-        margin-bottom: 20px;
-        line-height: 27px;
-        color: #666;
+      p {
+        color: #555;
+        line-height: 25px;
       }
     </style>
   </head>
 
   <body>
     <main class="notice">
-      <h1 class="main-message">No emails sent. Maybe because:</h1>
-      <ul>
-        <li>
-          <strong>Not using Bamboo.LocalAdapter.</strong> Make sure you have
-          your mailer configured to use Bamboo.LocalAdapter or the
-          emails will not show up here.
-        </li>
-
-        <li>
-          <strong>You recently restarted your server.</strong> The previewer
-          does not persist emails so whenever you restart the server the list
-          will be cleared.
-        </li>
-      </ul>
-    </main>
+      <h1>Email not found</h1>
+      <p>
+        This may be because the server was restarted.
+        <br>Go <a href="<%= @base_path %>/">back to email index</a> to see all emails.
+      </p>
+    </section>
   </body>
 </html>

--- a/lib/bamboo/plug/sent_email_viewer/email_preview_plug.ex
+++ b/lib/bamboo/plug/sent_email_viewer/email_preview_plug.ex
@@ -1,4 +1,4 @@
-defmodule Bamboo.EmailPreviewPlug do
+defmodule Bamboo.SentEmailViewerPlug do
   use Plug.Router
   require EEx
   alias Bamboo.SentEmail
@@ -30,10 +30,10 @@ defmodule Bamboo.EmailPreviewPlug do
 
         if Mix.env == :dev do
           # If using Phoenix
-          forward "/sent_emails", Bamboo.EmailPreviewPlug
+          forward "/sent_emails", Bamboo.SentEmailViewerPlug
 
           # If using Plug.Router, make sure to add the `to`
-          forward "/sent_emails", to: Bamboo.EmailPreviewPlug
+          forward "/sent_emails", to: Bamboo.SentEmailViewerPlug
         end
       end
 

--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -1,4 +1,4 @@
-defmodule Bamboo.EmailPreviewPlug.Helper do
+defmodule Bamboo.SentEmailViewerPlug.Helper do
   import Bamboo.SentEmail
 
   @moduledoc false

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>Email Preview</title>
+    <title>Sent Email</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
       body {
@@ -88,7 +88,7 @@
         text-overflow: ellipsis;
       }
 
-      .email-preview-pane {
+      .email-detail-pane {
         width: 100%;
         padding: 35px;
         padding-left: 0;
@@ -96,43 +96,43 @@
         flex-direction: column;
       }
 
-      .email-preview-hero {
+      .email-detail-hero {
         display: flex;
         flex-direction: column;
         padding-left: 20px;
       }
 
-      .email-preview-subject {
+      .email-detail-subject {
         font-weight: bold;
         font-size: 22px;
         padding: 10px 0;
       }
 
-      .email-preview-bodies-container {
+      .email-detail-bodies-container {
         border: 1px solid #eee;
         border-radius: 5px;
         padding: 20px;
         margin-top: 30px;
       }
 
-      .email-preview-body-label {
+      .email-detail-body-label {
         padding: 0;
         margin: 0 0 12px 0;
         font-size: 15px;
         font-weight: 700;
       }
 
-      .email-preview-recipients,
-      .email-preview-headers {
+      .email-detail-recipients,
+      .email-detail-headers {
         color: #aaa;
       }
 
-      .email-preview-recipients strong,
-      .email-preview-headers strong {
+      .email-detail-recipients strong,
+      .email-detail-headers strong {
         color: #555;
       }
 
-      .email-preview-body {
+      .email-detail-body {
         margin: 15px 0 25px 0;
       }
     </style>
@@ -143,36 +143,36 @@
       <aside class="email-sidebar">
         <%= for email <- @emails do %>
           <a
-            class="email-summary <%= Bamboo.EmailPreviewPlug.Helper.selected_email_class(email, @selected_email) %>"
+            class="email-summary <%= Bamboo.SentEmailViewerPlug.Helper.selected_email_class(email, @selected_email) %>"
             href="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(email)}" %>">
             <span class="email-summary-subject truncate"><%= email.subject %></span>
             <span class="email-summary-recipients truncate">
               <%= Bamboo.Email.get_address(email.from) %>
-              to <%= Bamboo.EmailPreviewPlug.Helper.email_addresses(email) %>
+              to <%= Bamboo.SentEmailViewerPlug.Helper.email_addresses(email) %>
             </span>
             <span class="email-summary-body-excerpt"><%= email.text_body %></span>
           </a>
         <% end %>
       </aside>
-      <section class="email-preview-pane">
-        <section class="email-preview-hero">
-          <span class="email-preview-subject"><%= @selected_email.subject %></span>
-          <span class="email-preview-recipients">
+      <section class="email-detail-pane">
+        <section class="email-detail-hero">
+          <span class="email-detail-subject"><%= @selected_email.subject %></span>
+          <span class="email-detail-recipients">
             From <strong><%= Bamboo.Email.get_address(@selected_email.from) %></strong>
-            to <strong><%= Bamboo.EmailPreviewPlug.Helper.email_addresses(@selected_email) %></strong>
+            to <strong><%= Bamboo.SentEmailViewerPlug.Helper.email_addresses(@selected_email) %></strong>
           </span>
-          <span class="email-preview-headers">
+          <span class="email-detail-headers">
             <%= for {header, value} <- @selected_email.headers do %>
-              <div class="email-preview-header">
-                <%= header %> <strong><%= Bamboo.EmailPreviewPlug.Helper.format_headers(value) %></strong>
+              <div class="email-detail-header">
+                <%= header %> <strong><%= Bamboo.SentEmailViewerPlug.Helper.format_headers(value) %></strong>
               </div>
             <% end %>
           </span>
         </section>
 
-        <section class="email-preview-bodies-container">
-          <h3 class="email-preview-body-label">HTML body</h3>
-          <p class="email-preview-body">
+        <section class="email-detail-bodies-container">
+          <h3 class="email-detail-body-label">HTML body</h3>
+          <p class="email-detail-body">
             <script>
             function adjustFrameHeight(iframe) {
               var body = iframe.contentWindow.document.body;
@@ -182,9 +182,9 @@
             <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
           </p>
 
-          <h3 class="email-preview-body-label">Text Body</h3>
-          <p class="email-preview-body">
-            <%= Bamboo.EmailPreviewPlug.Helper.format_text(@selected_email.text_body) %>
+          <h3 class="email-detail-body-label">Text Body</h3>
+          <p class="email-detail-body">
+            <%= Bamboo.SentEmailViewerPlug.Helper.format_text(@selected_email.text_body) %>
           </p>
         </section>
       </section>

--- a/lib/bamboo/plug/sent_email_viewer/no_emails.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/no_emails.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>Email Preview</title>
+    <title>Sent Email</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
       html {
@@ -24,9 +24,13 @@
         width: 80%;
         max-width: 500px;
         padding: 40px 50px;
-        text-align: center;
         background-color: #f8f8f8;
         border-radius: 12px;
+      }
+
+      .main-message {
+        text-align: center;
+        margin-bottom: 40px;
       }
 
       h1 {
@@ -34,20 +38,30 @@
         font-size: 18px;
       }
 
-      p {
-        color: #555;
-        line-height: 25px;
+      li {
+        margin-bottom: 20px;
+        line-height: 27px;
+        color: #666;
       }
     </style>
   </head>
 
   <body>
     <main class="notice">
-      <h1>Email not found</h1>
-      <p>
-        This may be because the server was restarted.
-        <br>Go <a href="<%= @base_path %>/">back to email index</a> to see all emails.
-      </p>
-    </section>
+      <h1 class="main-message">No emails sent. Maybe because:</h1>
+      <ul>
+        <li>
+          <strong>Not using Bamboo.LocalAdapter.</strong> Make sure you have
+          your mailer configured to use Bamboo.LocalAdapter or the
+          emails will not show up here.
+        </li>
+
+        <li>
+          <strong>You recently restarted your server.</strong> The viewer
+          does not persist emails so whenever you restart the server the list
+          will be cleared.
+        </li>
+      </ul>
+    </main>
   </body>
 </html>

--- a/lib/mix/start_sent_email_viewer_task.ex
+++ b/lib/mix/start_sent_email_viewer_task.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Bamboo.StartEmailPreview do
+defmodule Mix.Tasks.Bamboo.StartSentEmailViewer do
   use Mix.Task
 
   @moduledoc false
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Bamboo.StartEmailPreview do
   def run(_) do
     Mix.Task.run "app.start"
     {:ok, _} = Application.ensure_all_started(:cowboy)
-    Plug.Adapters.Cowboy.http Bamboo.EmailPreviewPlug, [], port: 4003
+    Plug.Adapters.Cowboy.http Bamboo.SentEmailViewerPlug, [], port: 4003
 
     for index <- 0..5 do
       Bamboo.Email.new_email(
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.Bamboo.StartEmailPreview do
       |> Bamboo.SentEmail.push
     end
 
-    IO.puts "Running email preview on port 4003"
+    IO.puts "Running sent email viewer on port 4003"
     no_halt()
   end
 


### PR DESCRIPTION
The new name is more in line with what the plug is actually doing and
allows us to add an EmailPreviewPlug in the future if we so choose.