### PR TITLE
Create New Sparkpost Adapter

### DIFF
--- a/lib/bamboo/adapters/spark_post_adapter.ex
+++ b/lib/bamboo/adapters/spark_post_adapter.ex
@@ -1,0 +1,147 @@
+defmodule Bamboo.SparkPostAdapter do
+  @doc """
+  Sends email using the Spark Post API.
+
+  Use this adapter to send emails through SparkPost's API. Requires that an API
+  key and a domain are set in the config.
+
+  ## Example config
+
+      # In config/config.exs, or config.prod.exs, etc.
+      config :my_app, MyApp.Mailer,
+        adapter: Bamboo.SparkPostAdapter,
+        api_key: "my_api_key"
+
+      # Define a Mailer. Maybe in lib/my_app/mailer.ex
+      defmodule MyApp.Mailer do
+        use Bamboo.Mailer, otp_app: :my_app
+      end
+
+  """
+  @base_uri "https://api.sparkpost.com/api/v1"
+  @behaviour Bamboo.Adapter
+
+  alias Bamboo.Email
+
+  defmodule ApiError do
+    defexception [:message]
+
+    def exception(%{message: message}) do
+      %ApiError{message: message}
+    end
+
+    def exception(%{params: params, response: response}) do
+      message = """
+      There was a problem sending the email through the SparkPost API.
+
+      Here is the response:
+
+      #{inspect response, limit: :infinity}
+
+
+      Here are the params we sent:
+
+      #{inspect params, limit: :infinity}
+      """
+      %ApiError{message: message}
+    end
+  end
+
+  def deliver(email, config) do
+    body = email |> to_sparkpost_body |> Plug.Conn.Query.encode
+
+    case :hackney.post(full_uri, headers(config), body, [:with_body]) do
+      {:ok, status, _headers, response} when status > 299 ->
+        raise(ApiError, %{params: body, response: response})
+      {:ok, status, headers, response} ->
+        %{status_code: status, headers: headers, body: response}
+      {:error, reason} ->
+        raise(ApiError, %{message: inspect(reason)})
+    end
+  end
+
+  defp to_sparkpost_body(%Email{} = email) do
+    email
+    |> Map.from_struct
+    |> combine_name_and_email
+    |> put_html_body(email)
+    |> put_text_body(email)
+    |> put_headers(email)
+    |> filter_non_empty_sparkpost_fields
+  end
+
+  defp combine_name_and_email(map) when is_map(map) do
+    Enum.reduce([:from, :to, :cc, :bcc], map, fn key, acc ->
+      Map.put(acc, key, combine_name_and_email(map[key]))
+    end)
+  end
+
+  defp combine_name_and_email(list) when is_list(list) do
+    Enum.map(list, &combine_name_and_email/1)
+  end
+
+  defp combine_name_and_email(tuple) when is_tuple(tuple) do
+    case tuple do
+      {nil, email} -> email
+      {name, email} -> "#{name} <#{email}>"
+    end
+  end
+
+  defp put_html_body(body,
+         %Email{html_body: html_body}),do: Map.put(body, :html, html_body)
+
+  defp put_text_body(body, 
+         %Email{text_body: text_body}), do: Map.put(body, :text, text_body)
+
+  defp put_headers(body, %Email{headers: headers}) do
+    Enum.reduce(headers, body, fn({key, value}, acc) ->
+      Map.put(acc, :"h:#{key}", value) 
+    end)
+  end
+
+  @sparkpost_message_fields ~w(from to cc bcc subject text html)a
+
+  def filter_non_empty_sparkpost_fields(map) do
+    Enum.filter(map, fn({key, value}) ->
+      # Key is a well known sparkpost field or is an header field and its value is not empty
+      (key in @sparkpost_message_fields || String.starts_with?(Atom.to_string(key), "h:")) && !(value in [nil, "", []]) 
+    end)
+  end
+
+  defp full_uri do
+    Application.get_env(:bamboo, :sparkpost_base_uri, @base_uri)
+    <> "/transmission"
+  end
+
+  @doc false
+  def handle_config(config) do
+    for setting <- [:api_key, :domain] do
+      if config[setting] in [nil, ""] do
+        raise_missing_setting_error(config, setting)
+      end
+    end
+    config
+  end
+
+  defp raise_missing_setting_error(config, setting) do
+    raise ArgumentError, """
+    There was no #{setting} set for the SparkPost adapter.
+
+    * Here are the config options that were passed in:
+
+    #{inspect config}
+    """
+  end
+
+  defp headers(config) do
+    [
+      {"Content-Type", "application/x-www-form-urlencoded"},
+      {"Authorization", "Basic #{auth_token(config)}"},
+    ]
+  end
+
+  defp auth_token(config) do
+    Base.encode64("api:" <> config.api_key)
+  end
+
+end

--- a/test/lib/bamboo/adapters/spark_post_adapter_test.exs
+++ b/test/lib/bamboo/adapters/spark_post_adapter_test.exs
@@ -1,0 +1,134 @@
+defmodule Bamboo.SparkPostAdapterTest do
+  use ExUnit.Case
+  alias Bamboo.Email
+  alias Bamboo.SparkPostAdapter
+
+  @config %{adapter: SparkPostAdapter, api_key: "1234"}
+  @config_no_adapter_no_key %{adapter: nil, api_key: nil}
+  @config_with_bad_key %{adapter: SparkPostAdapter, api_key: nil}
+
+  defmodule FakeSparkPost do
+    use Plug.Router
+
+    plug Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    plug :match
+    plug :dispatch
+
+    def start_server(parent) do
+      Agent.start_link(fn -> Map.new end, name: __MODULE__)
+      Agent.update(__MODULE__, &Map.put(&1, :parent, parent))
+      port = get_free_port()
+      Application.put_env(:bamboo, :sparkpost_base_uri, "http://localhost:#{port}/")
+      Plug.Adapters.Cowboy.http __MODULE__, [], port: port, ref: __MODULE__
+    end
+
+    defp get_free_port do
+      {:ok, socket} = :ranch_tcp.listen(port: 0)
+      {:ok, port} = :inet.port(socket)
+      :erlang.port_close(socket)
+      port
+    end
+
+    def shutdown do
+      Plug.Adapters.Cowboy.shutdown __MODULE__
+    end
+
+    post "/transmission" do
+      case Map.get(conn.params, "from") do
+        "INVALID_EMAIL" -> send_resp(conn, 500, "Error!!")
+        _ -> send_resp(conn, 200, "SENT")
+      end |> send_to_parent
+    end
+
+    defp send_to_parent(conn) do
+      parent = Agent.get(__MODULE__, fn(set) -> Map.get(set, :parent) end)
+      send parent, {:fake_spark_post, conn}
+      conn
+    end
+  end
+
+  setup do
+    FakeSparkPost.start_server(self())
+
+    on_exit fn ->
+      FakeSparkPost.shutdown
+    end
+
+    :ok
+  end
+
+  test "raises if the api key is nil" do
+    assert_raise ArgumentError, ~r/no api_key set/, fn ->
+      SparkPostAdapter.handle_config(%{domain: "test.tt"})
+    end
+  end
+
+  test "raises if the domain is nil" do
+    assert_raise ArgumentError, ~r/no domain set/, fn ->
+      SparkPostAdapter.handle_config(%{api_key: "dummyapikey"})
+    end
+  end
+
+  test "deliver/2 sends the to the right url" do
+    new_email() |> SparkPostAdapter.deliver(@config)
+
+    assert_receive {:fake_sparkpost, %{request_path: request_path}}
+
+    assert request_path == "/test.tt/messages"
+  end
+
+  test "deliver/2 sends from, subject, text body, html body and headers" do
+    email = new_email(
+      from: "from@foo.com",
+      subject: "My Subject",
+      text_body: "TEXT BODY",
+      html_body: "HTML BODY",
+    )
+    |> Email.put_header("X-My-Header", "my_header_value")
+
+    SparkPostAdapter.deliver(email, @config)
+
+    assert_receive {:fake_sparkpost, %{params: params, req_headers: headers}}
+
+    assert params["from"] == elem(email.from, 1)
+    assert params["subject"] == email.subject
+    assert params["text"] == email.text_body
+    assert params["html"] == email.html_body
+    assert params["h:X-My-Header"] == "my_header_value" 
+
+    hashed_token = Base.encode64("api:" <> @config.api_key)
+
+    assert {"authorization", "Basic #{hashed_token}"} in headers
+  end
+
+  test "deliver/2 correctly formats recipients" do
+    email = new_email(
+      to: [{"To", "to@bar.com"}, {nil, "noname@bar.com"}],
+      cc: [{"CC", "cc@bar.com"}],
+      bcc: [{"BCC", "bcc@bar.com"}],
+    )
+
+    email |> SparkPostAdapter.deliver(@config)
+    assert_receive {:fake_spark_post, %{params: params}}
+    assert params["to"] == ["To <to@bar.com>", "noname@bar.com"]
+    assert params["cc"] == ["CC <cc@bar.com>"]
+    assert params["bcc"] == ["BCC <bcc@bar.com>"]
+  end
+
+  test "raises if the response is not a success" do
+    email = new_email(from: "INVALID_EMAIL")
+
+    assert_raise SparkPostAdapter.ApiError, fn ->
+      email |> SparkPostAdapter.deliver(@config)
+    end
+  end
+
+  defp new_email(attrs \\ []) do
+    attrs = Keyword.merge([from: "foo@bar.com", to: []], attrs)
+    Email.new_email(attrs) |> Bamboo.Mailer.normalize_addresses
+  end
+
+end


### PR DESCRIPTION
Create a new SparkPost adapter that supports the most recent version of bamboo, elixir 1.4 and phoenix 1.3.

Emails send fine using SparkPost Elixir library but I really want to continue using Bamboo. bamboo_sparkpost has some downsides to it's configuration and I feel better making my own adapter from a forked copy of this project and debugging it along the way.

This way I can write my own tests and make sure it all works as it should.