### PR TITLE
Remove obsolete heroku instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,20 +217,6 @@ SendGrid offers extra features on top of regular SMTP email like transactional
 templates with substitution tags. See
 [Bamboo.SendGridHelper](https://hexdocs.pm/bamboo/Bamboo.SendGridHelper.html).
 
-## Heroku Configuration
-
-If you are deploying to Heroku, you will need to ensure that your configuration
-variables are available at compile time. This is done in the [build pack config].
-
-```
-config_vars_to_export=(
-  DATABASE_URL
-  MANDRILL_API_KEY
-)
-```
-
-[build pack config]: https://github.com/HashNuke/heroku-buildpack-elixir#specifying-config-vars-to-export-at-compile-time
-
 ## Testing
 
 You can use the Bamboo.TestAdapter along with [Bamboo.Test] to make testing your

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -44,15 +44,6 @@ defmodule Bamboo.MandrillAdapter do
       Here are the params we sent:
 
       #{inspect filtered_params, limit: :infinity}
-
-      If you are deploying to Heroku and using ENV variables to handle your API key,
-      you will need to explicitly export the variables so they are available at compile time.
-      Add the following configuration to your elixir_buildpack.config:
-
-      config_vars_to_export=(
-        DATABASE_URL
-        MANDRILL_API_KEY
-      )
       """
       %ApiError{message: message}
     end

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -49,15 +49,6 @@ defmodule Bamboo.SendGridAdapter do
       Here are the params we sent:
 
       #{inspect filtered_params, limit: :infinity}
-
-      If you are deploying to Heroku and using ENV variables to handle your API key,
-      you will need to explicitly export the variables so they are available at compile time.
-      Add the following configuration to your elixir_buildpack.config:
-
-      config_vars_to_export=(
-        DATABASE_URL
-        SENDGRID_API_KEY
-      )
       """
       %ApiError{message: message}
     end


### PR DESCRIPTION
Since this [commit](https://github.com/HashNuke/heroku-buildpack-elixir/commit/6251590e3a354d4b8ac99960977daf417d3128db) the buildpack exports all environment variables by default so this section is unnecessary