### PR TITLE
Attachments: Support file data in attachment struct + mailgun attachment support

### DIFF
--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -108,11 +108,11 @@ defmodule Bamboo.MandrillAdapter do
   defp attachments(%{attachments: attachments}) do
     attachments
     |> Enum.reverse
-    |> Enum.map(fn(att) ->
+    |> Enum.map(fn(attachment) ->
       %{
-        name: att.filename,
-        type: att.content_type,
-        content: Base.encode64(File.read!(att.path))
+        name: attachment.filename,
+        type: attachment.content_type,
+        content: Base.encode64(attachment.data)
       }
     end)
   end

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -52,4 +52,7 @@ defmodule Bamboo.TestAdapter do
   def clean_assigns(email) do
     %{email | assigns: :assigns_removed_for_testing}
   end
+
+  @doc false
+  def supports_attachments?, do: true
 end

--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -2,16 +2,16 @@ defmodule Bamboo.Attachment do
   @moduledoc """
   """
 
-  defstruct filename: nil, content_type: nil, path: nil
+  defstruct filename: nil, content_type: nil, path: nil, data: nil
 
   @doc ~S"""
   Creates a new Attachment
 
   Examples:
-    Attachment.new("/path/to/attachment.png")
-    Attachment.new("/path/to/attachment.png", filename: "image.png")
-    Attachment.new("/path/to/attachment.png", filename: "image.png", content_type: "image/png")
-    Attachment.new(params["file"]) # Where params["file"] is a %Plug.Upload
+    Bamboo.Attachment.new("/path/to/attachment.png")
+    Bamboo.Attachment.new("/path/to/attachment.png", filename: "image.png")
+    Bamboo.Attachment.new("/path/to/attachment.png", filename: "image.png", content_type: "image/png")
+    Bamboo.Attachment.new(params["file"]) # Where params["file"] is a %Plug.Upload
   """
   def new(path, opts \\ [])
   if Code.ensure_loaded?(Plug) do
@@ -21,7 +21,8 @@ defmodule Bamboo.Attachment do
   def new(path, opts) do
     filename = opts[:filename] || Path.basename(path)
     content_type = opts[:content_type] || determine_content_type(path)
-    %__MODULE__{path: path, filename: filename, content_type: content_type}
+    data = File.read!(path)
+    %__MODULE__{path: path, data: data, filename: filename, content_type: content_type}
   end
 
   defp determine_content_type(path) do

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -218,7 +218,13 @@ defmodule Bamboo.Email do
       #...
     end
   """
-  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{filename: _filename, data: _data} = attachment) do
+  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{filename: nil}) do
+    raise "You must provide a filename for the attachment."
+  end
+  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{data: nil}) do
+    raise "The attachment must contain data."
+  end
+  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{} = attachment) do
     %{email | attachments: [attachment | attachments]}
   end
 

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -218,11 +218,11 @@ defmodule Bamboo.Email do
       #...
     end
   """
-  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{filename: nil}) do
-    raise "You must provide a filename for the attachment."
+  def put_attachment(%__MODULE__{attachments: _}, %Attachment{filename: nil} = attachment) do
+    raise "You must provide a filename for the attachment, instead got: #{inspect attachment}"
   end
-  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{data: nil}) do
-    raise "The attachment must contain data."
+  def put_attachment(%__MODULE__{attachments: _}, %Attachment{data: nil} = attachment) do
+    raise "The attachment must contain data, instead got: #{inspect attachment}"
   end
   def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{} = attachment) do
     %{email | attachments: [attachment | attachments]}

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -90,7 +90,7 @@ defmodule Bamboo.Email do
       assigns: %{},
       private: %{}
 
-  alias Bamboo.Email
+  alias Bamboo.{Email, Attachment}
 
   @address_functions ~w(from to cc bcc)a
   @attribute_pipe_functions ~w(subject text_body html_body)a
@@ -203,7 +203,27 @@ defmodule Bamboo.Email do
   end
 
   @doc ~S"""
-  Adds an attachment to the email
+  Adds an data attachment to the email
+
+  ## Example
+    put_attachment(email, %Bamboo.Attachment{})
+
+  Requires the fields filename and data of the %Bamboo.Attachment{} struct to be set.
+
+  ## Example
+    def create(conn, params) do
+      #...
+      email
+      |> put_attachment(%Bamboo.Attachment{filname: "event.ics", data: "BEGIN:VCALENDAR..."})
+      #...
+    end
+  """
+  def put_attachment(%__MODULE__{attachments: attachments} = email, %Attachment{filename: _filename, data: _data} = attachment) do
+    %{email | attachments: [attachment | attachments]}
+  end
+
+  @doc ~S"""
+  Adds an file attachment to the email
 
   ## Example
     put_attachment(email, path, opts \\ [])

--- a/test/lib/bamboo/attachments_test.exs
+++ b/test/lib/bamboo/attachments_test.exs
@@ -8,7 +8,7 @@ defmodule Bamboo.AttachmentTest do
     attachment = Attachment.new(path)
     assert attachment.content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     assert attachment.filename == "attachment.docx"
-    assert attachment.path == path
+    assert attachment.data
   end
 
   test "create an attachment with an unknown content type" do
@@ -37,7 +37,7 @@ defmodule Bamboo.AttachmentTest do
     attachment = Attachment.new(upload)
     assert attachment.content_type == "application/msword"
     assert attachment.filename == "test.docx"
-    assert attachment.path == path
+    assert attachment.data
   end
 
   test "create an attachment from a Plug Upload struct with overrides" do
@@ -48,6 +48,6 @@ defmodule Bamboo.AttachmentTest do
     attachment = Attachment.new(upload, filename: "my-attachment.doc", content_type: "application/other")
     assert attachment.content_type == "application/other"
     assert attachment.filename == "my-attachment.doc"
-    assert attachment.path == path
+    assert attachment.data
   end
 end

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -77,7 +77,14 @@ defmodule Bamboo.EmailTest do
     assert email.private["foo"] == "bar"
   end
 
-  test "put_attachment/3 atts an attachment to the attachments list" do
+  test "put_attachment/2 adds an attachment to the attachments list" do
+    attachment = %Bamboo.Attachment{filename: "attachment.docx", data: "content"}
+    email = new_email() |> put_attachment(attachment)
+
+    assert [%Bamboo.Attachment{filename: "attachment.docx"}] = email.attachments
+  end
+
+  test "put_attachment/3 adds an attachment to the attachments list" do
     path = Path.join(__DIR__, "../../support/attachment.docx")
     email = new_email() |> put_attachment(path)
 

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -88,7 +88,8 @@ defmodule Bamboo.EmailTest do
     test "with no filename throws an error" do
       attachment = %Bamboo.Attachment{filename: nil, data: "content"}
 
-      assert_raise RuntimeError, "You must provide a filename for the attachment.", fn ->
+      msg = "You must provide a filename for the attachment, instead got: %Bamboo.Attachment{content_type: nil, data: \"content\", filename: nil, path: nil}"
+      assert_raise RuntimeError, msg, fn ->
         new_email() |> put_attachment(attachment)
       end
     end
@@ -96,7 +97,8 @@ defmodule Bamboo.EmailTest do
     test "with no data throws an error" do
       attachment = %Bamboo.Attachment{filename: "attachment.docx", data: nil}
 
-      assert_raise RuntimeError, "The attachment must contain data.", fn ->
+      msg = "The attachment must contain data, instead got: %Bamboo.Attachment{content_type: nil, data: nil, filename: \"attachment.docx\", path: nil}"
+      assert_raise RuntimeError, msg, fn ->
         new_email() |> put_attachment(attachment)
       end
     end

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -77,11 +77,29 @@ defmodule Bamboo.EmailTest do
     assert email.private["foo"] == "bar"
   end
 
-  test "put_attachment/2 adds an attachment to the attachments list" do
-    attachment = %Bamboo.Attachment{filename: "attachment.docx", data: "content"}
-    email = new_email() |> put_attachment(attachment)
+  describe "put_attachment/2" do
+    test "adds an attachment to the attachments list" do
+      attachment = %Bamboo.Attachment{filename: "attachment.docx", data: "content"}
+      email = new_email() |> put_attachment(attachment)
 
-    assert [%Bamboo.Attachment{filename: "attachment.docx"}] = email.attachments
+      assert [%Bamboo.Attachment{filename: "attachment.docx"}] = email.attachments
+    end
+
+    test "with no filename throws an error" do
+      attachment = %Bamboo.Attachment{filename: nil, data: "content"}
+
+      assert_raise RuntimeError, "You must provide a filename for the attachment.", fn ->
+        new_email() |> put_attachment(attachment)
+      end
+    end
+
+    test "with no data throws an error" do
+      attachment = %Bamboo.Attachment{filename: "attachment.docx", data: nil}
+
+      assert_raise RuntimeError, "The attachment must contain data.", fn ->
+        new_email() |> put_attachment(attachment)
+      end
+    end
   end
 
   test "put_attachment/3 adds an attachment to the attachments list" do


### PR DESCRIPTION
As discussed in #286 @sbrink and I were working on an improved version of the attachment support:

### Changes

* supports `|> put_attachment %Attachment{filename: "event.ics", data: "raw content..", content_type: "text/calendar"}`
* sets `Attachment.data` when using `|> put_attachment "/hi.jpg"` or `|> put_attachment %Plug{..}`
* supports attachments in the mailgun and test adapter
* updates the mandrill adapter to use the `attachment.data`

### Todo

* tests for the mailgun adapter (attachment support)