### PR TITLE
Convert send_grid_adapter to SendGrid API v3

### DIFF
--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -35,8 +35,8 @@ defmodule Bamboo.SendGridAdapterTest do
       Plug.Adapters.Cowboy.shutdown __MODULE__
     end
 
-    post "/mail.send.json" do
-      case Map.get(conn.params, "from") do
+    post "/mail/send" do
+      case get_in(conn.params, ["from", "email"]) do
         "INVALID_EMAIL" -> conn |> send_resp(500, "Error!!") |> send_to_parent
         _ -> conn |> send_resp(200, "SENT") |> send_to_parent
       end
@@ -74,7 +74,7 @@ defmodule Bamboo.SendGridAdapterTest do
 
     assert_receive {:fake_sendgrid, %{request_path: request_path}}
 
-    assert request_path == "/mail.send.json"
+    assert request_path == "/mail/send"
   end
 
   test "deliver/2 sends from, html and text body, subject, and headers" do
@@ -90,11 +90,11 @@ defmodule Bamboo.SendGridAdapterTest do
 
     assert_receive {:fake_sendgrid, %{params: params, req_headers: headers}}
 
-    assert params["fromname"] == email.from |> elem(0)
-    assert params["from"] == email.from |> elem(1)
+    assert params["from"]["name"] == email.from |> elem(0)
+    assert params["from"]["email"] == email.from |> elem(1)
     assert params["subject"] == email.subject
-    assert params["text"] == email.text_body
-    assert params["html"] == email.html_body
+    assert Enum.member?(params["content"], %{"type" => "text/plain", "value" => email.text_body})
+    assert Enum.member?(params["content"], %{"type" => "text/html", "value" => email.html_body})
     assert Enum.member?(headers, {"authorization", "Bearer #{@config[:api_key]}"})
   end
 
@@ -108,12 +108,13 @@ defmodule Bamboo.SendGridAdapterTest do
     email |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["to"] == ["to@bar.com", "noname@bar.com"]
-    assert params["toname"] == ["To", ""]
-    assert params["cc"] == ["cc@bar.com"]
-    assert params["ccname"] == ["CC"]
-    assert params["bcc"] == ["bcc@bar.com"]
-    assert params["bccname"] == ["BCC"]
+    addressees = List.first(params["personalizations"])
+    assert addressees["to"] == [
+      %{"name" => "To", "email" => "to@bar.com"},
+      %{"email" => "noname@bar.com"}
+    ]
+    assert addressees["cc"] == [%{"name" => "CC", "email" => "cc@bar.com"}]
+    assert addressees["bcc"] == [%{"name" => "BCC", "email" => "bcc@bar.com"}]
   end
 
   test "deliver/2 correctly handles templates" do
@@ -128,20 +129,10 @@ defmodule Bamboo.SendGridAdapterTest do
     |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["text"] == " "
-    assert Poison.decode(params["x-smtpapi"]) == {:ok, %{
-        "sub" => %{
-          "%foo%" => ["bar"]
-        },
-        "filters" => %{
-          "templates" => %{
-            "settings" => %{
-              "enable" => 1,
-              "template_id" => "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
-            }
-          }
-        }
-      }}
+    personalization = List.first(params["personalizations"])
+    assert params["content"] == [%{"type" => "text/plain", "value" => " "}]
+    assert params["template_id"] == "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
+    assert personalization["substitutions"] == %{"%foo%" => ["bar"]}
   end
 
   test "deliver/2 correctly formats reply-to from headers" do
@@ -150,7 +141,7 @@ defmodule Bamboo.SendGridAdapterTest do
     email |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["replyto"] == "foo@bar.com"
+    assert params["reply_to"] == %{"email" => "foo@bar.com"}
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
The existing `SendGridAdapter` uses v2 of the SendGrid API.  In https://sendgrid.com/docs/API_Reference/Web_API/mail.html, it recommends migrating to the new v3 API:

> To current v2 users: We encourage migrating to the new endpoint to take advantage of upcoming features.

I was looking at adding attachment support to the existing adapter, and found that it would be much easier to do with the v3 API instead.  So, I'm submitting this PR first, and will then add attachment support on top of it.

For reference, the v3 API docs are at https://sendgrid.com/docs/API_Reference/api_v3.html.

I've done my best to preserve the existing API for both the adapter and the helper, but I've changed the internal representation of the private data that the helper adds to the e-mail.  The new format is simpler and less coupled to the resulting API format:

```
%{
  send_grid_template: %{
    template_id: "YOUR ID HERE",
    substitutions: %{
      "%foo%" => "bar"
    }
  }
}
```

I've tested this adapter in an existing application and it works perfectly, though that app doesn't use all of the available features.

I'm still relatively new to Elixir, so any suggestions for cleaning up the code or making it more idiomatic are most welcome.