### PR TITLE
Support attachments in SendGridAdapter

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -167,6 +167,7 @@ defmodule Bamboo.SendGridAdapter do
   end
   defp put_template_substitutions(body, _), do: body
 
+  defp put_attachments(body, %Email{attachments: []}), do: body
   defp put_attachments(body, %Email{attachments: attachments}) do
     transformed = attachments
     |> Enum.reverse
@@ -179,7 +180,6 @@ defmodule Bamboo.SendGridAdapter do
     end)
     Map.put(body, :attachments, transformed)
   end
-  defp put_attachments(body, _), do: body
 
   defp ensure_content_provided(%{content: []} = body, email) do
     put_content(body, %Email{email | text_body: " "})

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -56,6 +56,9 @@ defmodule Bamboo.SendGridAdapter do
     end
   end
 
+  @doc false
+  def supports_attachments?, do: true
+
   defp get_key(config) do
     case Map.get(config, :api_key) do
       nil -> raise_api_key_error(config)
@@ -88,6 +91,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_subject(email)
     |> put_content(email)
     |> put_template_id(email)
+    |> put_attachments(email)
   end
 
   defp put_from(body, %Email{from: from}) do
@@ -162,6 +166,20 @@ defmodule Bamboo.SendGridAdapter do
     Map.put(body, :substitutions, substitutions)
   end
   defp put_template_substitutions(body, _), do: body
+
+  defp put_attachments(body, %Email{attachments: attachments}) do
+    transformed = attachments
+    |> Enum.reverse
+    |> Enum.map(fn(attachment) ->
+      %{
+        filename: attachment.filename,
+        type: attachment.content_type,
+        content: Base.encode64(File.read!(attachment.path))
+      }
+    end)
+    Map.put(body, :attachments, transformed)
+  end
+  defp put_attachments(body, _), do: body
 
   defp ensure_content_provided(%{content: []} = body, email) do
     put_content(body, %Email{email | text_body: " "})

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -174,7 +174,7 @@ defmodule Bamboo.SendGridAdapter do
       %{
         filename: attachment.filename,
         type: attachment.content_type,
-        content: Base.encode64(File.read!(attachment.path))
+        content: Base.encode64(attachment.data)
       }
     end)
     Map.put(body, :attachments, transformed)

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -153,6 +153,14 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["reply_to"] == %{"email" => "foo@bar.com"}
   end
 
+  test "deliver/2 omits attachments key if no attachments" do
+    email = new_email()
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    refute Map.has_key?(params, "attachments")
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -77,7 +77,7 @@ defmodule Bamboo.SendGridAdapterTest do
     assert request_path == "/mail/send"
   end
 
-  test "deliver/2 sends from, html and text body, subject, and headers" do
+  test "deliver/2 sends from, html and text body, subject, headers and attachment" do
     email = new_email(
       from: {"From", "from@foo.com"},
       subject: "My Subject",
@@ -85,9 +85,11 @@ defmodule Bamboo.SendGridAdapterTest do
       html_body: "HTML BODY",
     )
     |> Email.put_header("Reply-To", "reply@foo.com")
+    |> Email.put_attachment(Path.join(__DIR__, "../../../support/attachment.txt"))
 
     email |> SendGridAdapter.deliver(@config)
 
+    assert SendGridAdapter.supports_attachments?
     assert_receive {:fake_sendgrid, %{params: params, req_headers: headers}}
 
     assert params["from"]["name"] == email.from |> elem(0)
@@ -96,6 +98,13 @@ defmodule Bamboo.SendGridAdapterTest do
     assert Enum.member?(params["content"], %{"type" => "text/plain", "value" => email.text_body})
     assert Enum.member?(params["content"], %{"type" => "text/html", "value" => email.html_body})
     assert Enum.member?(headers, {"authorization", "Bearer #{@config[:api_key]}"})
+    assert params["attachments"] == [
+      %{
+        "type" => "text/plain",
+        "filename" => "attachment.txt",
+        "content" => "VGVzdCBBdHRhY2htZW50Cg=="
+      }
+    ]
   end
 
   test "deliver/2 correctly formats recipients" do


### PR DESCRIPTION
**WARNING** This PR is built using the v3 SendGrid API that is currently pending in #293, so that PR should be merged first and then this PR rebased on top of master.  All of the diffs that are unique to this PR start at commit dc8e927.

Adds attachment support to `SendGridAdapter`.  The code and tests are very similar to `MandrillAdapter`.

If #292 gets merged before this PR, I'm happy to make the necessary changes here.