### PR TITLE
A backwards compatible link before v1.0 goes out

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Bamboo comes with a handy plug for viewing emails sent in development. Now you
 don't have to look at the logs to get password resets, confirmation links, etc.
 Just open up the sent email viewer and click the link.
 
-See [Bamboo.SentEmailViewerPlug](https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html)
+See [Bamboo.SentEmailViewerPlug](https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html).  Prior to v1.0, see [Bamboo.EmailPreviewPlug](https://hexdocs.pm/bamboo/Bamboo.EmailPreviewPlug.html)
 
 Here is what it looks like:
 


### PR DESCRIPTION

I know that the preview module name has changed, but until v1.0 goes out, the link on the main page is referencing a hex doc that does not exist.  This simple PR is a stop gap to avoid the 404 page when visiting https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html

<img width="532" alt="screen shot 2017-06-09 at 9 44 17 am" src="https://user-images.githubusercontent.com/48086/26978354-4998293e-4cf9-11e7-8e51-7626e17d1891.png">

It now includes a pre v1.0 link

<img width="568" alt="screen shot 2017-06-09 at 9 52 47 am" src="https://user-images.githubusercontent.com/48086/26978401-6c2876c0-4cf9-11e7-9fde-dde742071cef.png">
