### PR TITLE
%Response{} struct to handle deliver responses

### DIFF
--- a/lib/bamboo/adapter.ex
+++ b/lib/bamboo/adapter.ex
@@ -33,6 +33,7 @@ defmodule Bamboo.Adapter do
       end
   """
 
-  @callback deliver(%Bamboo.Email{}, %{}) :: any
+  @type response :: Bamboo.Response.t
+  @callback deliver(%Bamboo.Email{}, %{}) :: response
   @callback handle_config(map) :: map
 end

--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -27,6 +27,7 @@ defmodule Bamboo.LocalAdapter do
   """
 
   alias Bamboo.SentEmail
+  import Bamboo.Response, only: [local_response: 0]
 
   @behaviour Bamboo.Adapter
 
@@ -39,6 +40,7 @@ defmodule Bamboo.LocalAdapter do
   @doc "Adds email to Bamboo.SentEmail"
   def deliver(email, _config) do
     SentEmail.push(email)
+    local_response()
   end
 
   def handle_config(config), do: config

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -26,6 +26,7 @@ defmodule Bamboo.MandrillAdapter do
   @behaviour Bamboo.Adapter
 
   import Bamboo.ApiError
+  import Bamboo.Response, only: [new_response: 1]
 
   def deliver(email, config) do
     api_key = get_key(config)
@@ -38,7 +39,7 @@ defmodule Bamboo.MandrillAdapter do
         raise_api_error(@service_name, response, filtered_params)
 
       {:ok, status, headers, response} ->
-        %{status_code: status, headers: headers, body: response}
+        new_response(status_code: status, headers: headers, body: response)
 
       {:error, reason} ->
         raise_api_error(inspect(reason))

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -34,6 +34,7 @@ defmodule Bamboo.SendGridAdapter do
 
   alias Bamboo.Email
   import Bamboo.ApiError
+  import Bamboo.Response, only: [new_response: 1]
 
   def deliver(email, config) do
     api_key = get_key(config)
@@ -46,7 +47,7 @@ defmodule Bamboo.SendGridAdapter do
         raise_api_error(@service_name, response, filtered_params)
 
       {:ok, status, headers, response} ->
-        %{status_code: status, headers: headers, body: response}
+        new_response(status_code: status, headers: headers, body: response)
 
       {:error, reason} ->
         raise_api_error(inspect(reason))

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -19,10 +19,13 @@ defmodule Bamboo.TestAdapter do
 
   @behaviour Bamboo.Adapter
 
+  import Bamboo.Response, only: [local_response: 0]
+
   @doc false
   def deliver(email, _config) do
     email = clean_assigns(email)
     send(test_process(), {:delivered_email, email})
+    local_response()
   end
 
   defp test_process do

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -65,6 +65,7 @@ defmodule Bamboo.Email do
 
   @type address :: String.t() | {String.t(), String.t()}
   @type address_list :: nil | address | [address] | any
+  @type response :: Bamboo.Response.t
 
   @type t :: %__MODULE__{
           to: address_list,
@@ -73,12 +74,13 @@ defmodule Bamboo.Email do
           subject: nil | String.t(),
           html_body: nil | String.t(),
           text_body: nil | String.t(),
-          headers: %{String.t() => String.t()},
+          headers: %{String.t() => String.t},
           assigns: %{atom => any},
-          private: %{atom => any}
+          private: %{atom => any},
+          response: nil | response
         }
 
-  defstruct from: nil,
+        defstruct from: nil,
             to: nil,
             cc: nil,
             bcc: nil,
@@ -88,7 +90,8 @@ defmodule Bamboo.Email do
             headers: %{},
             attachments: [],
             assigns: %{},
-            private: %{}
+            private: %{},
+            response: nil
 
   alias Bamboo.{Email, Attachment}
 

--- a/lib/bamboo/response.ex
+++ b/lib/bamboo/response.ex
@@ -1,0 +1,25 @@
+defmodule Bamboo.Response do
+  @moduledoc """
+  Response from an `adapter.deliver/2` call.
+  """
+
+  @type headers :: [{binary, binary}] | %{binary => binary}
+  @type t :: %__MODULE__{
+    status_code: number,
+    headers: headers,
+    body: binary
+  }
+  defstruct status_code: nil, headers: nil, body: nil
+
+  @spec new_response(Enum.t) :: __MODULE__.t
+  def new_response(attrs \\ []) do
+    struct!(%__MODULE__{}, attrs)
+  end
+
+  @spec local_response() :: __MODULE__.t
+  def local_response do
+    new_response(status_code: 201, headers: %{}, body: some_body())
+  end
+
+  defp some_body, do: Poison.encode! %{id: "1", success: true, message: "email sent!"}
+end

--- a/test/lib/bamboo/adapters/local_adapter_test.exs
+++ b/test/lib/bamboo/adapters/local_adapter_test.exs
@@ -14,8 +14,9 @@ defmodule Bamboo.LocalAdapterTest do
   test "sent emails has emails that were delivered synchronously" do
     email = new_email(subject: "This is my email")
 
-    email |> LocalAdapter.deliver(@config)
+    response = email |> LocalAdapter.deliver(@config)
 
+    assert %Bamboo.Response{} = response
     assert [%Bamboo.Email{subject: "This is my email"}] = SentEmail.all()
   end
 end


### PR DESCRIPTION
This PR exposes the HTTP response from sending mail via the adapter.

- defines a `%Bamboo.Response{}` struct to store the responses.  Adapters now return a response with `Bamboo.Response.new_response/1`.
- defines a new `:response` key in `%Email{}` (can be `:nil` or `%Response{}`)
- merges the response from `adapter.deliver/2` with the email in `Mailer.deliver_now/3`
- leaves the `:response` key as `:nil` in the case we return `{:ok, pid}` from `Mailer.deliver_later/3`

Fixes #161 