### PR TITLE
Remove deprecated call

### DIFF
--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -27,7 +27,7 @@ defmodule Bamboo.Attachment do
 
   defp determine_content_type(path) do
     if Code.ensure_loaded?(Plug) do
-      Plug.MIME.path(path)
+      MIME.from_path(path)
     else
       "application/octet-stream"
     end


### PR DESCRIPTION
The current version of bamboo throws deprecation warnings at each use. 

```
Plug.MIME.path/1 is deprecated, please use MIME.from_path/1 instead
    (bamboo) lib/bamboo/attachment.ex:23: Bamboo.Attachment.new/2
    (bamboo) lib/bamboo/email.ex:250: Bamboo.Email.put_attachment/3
```

This removes the deprecated call.