### PR TITLE
Differentiate master/published SendGridHelper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ vars, templates, and scheduling emails to send in the future. See
 
 SendGrid offers extra features on top of regular SMTP email like transactional
 templates with substitution tags. See
-[Bamboo.SendGridHelper](https://hexdocs.pm/bamboo/Bamboo.SendgridHelper.html).
+[Bamboo.SendgridHelper](https://hexdocs.pm/bamboo/Bamboo.SendgridHelper.html)
+([Bamboo.SendGridHelper](https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/adapters/send_grid_helper.ex)
+if you're on master).
 
 ## Testing
 


### PR DESCRIPTION
This is to help out folks that are using the published version OR master branch of Bamboo get to the right place in documentation.

related: #324
related: #315 
related: #301 