### PR TITLE
Adds support for sendgrid custom args

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -92,6 +92,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_content(email)
     |> put_template_id(email)
     |> put_attachments(email)
+    |> put_custom_args(email)
   end
 
   defp put_from(body, %Email{from: from}) do
@@ -180,6 +181,12 @@ defmodule Bamboo.SendGridAdapter do
     end)
     Map.put(body, :attachments, transformed)
   end
+
+  defp put_custom_args(body, %Email{private: %{custom_args: args}}) do
+    body
+    |> Map.put(:custom_args, args)
+  end
+  defp put_custom_args(body, _), do: body  
 
   defp ensure_content_provided(%{content: []} = body, email) do
     put_content(body, %Email{email | text_body: " "})

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -14,6 +14,24 @@ defmodule Bamboo.SendGridHelper do
 
   @id_size 36
   @field_name :send_grid_template
+  @custom_args :custom_args
+
+  @doc """
+  Specify a custom argument values that are specific to the entire send that will be carried along with the email and its activity data.
+  Substitutions are not made on custom arguments within SendGrid.
+  The combined total size of these custom arguments may not exceed 10,000 bytes.
+
+  ## Example
+
+      email
+      |> with_custom_args("userId", "12345")
+  """
+  def with_custom_args(email, arg_name, arg_value) do
+    custom_args = Map.get(email.private, @custom_args, %{})
+    |> Map.put(arg_name, arg_value)
+    email
+    |> Email.put_private(@custom_args, custom_args)
+  end
 
   @doc """
   Specify the template for SendGrid to use for the context of the substitution

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -20,6 +20,7 @@ defmodule Bamboo.SendGridHelper do
   Specify a custom argument values that are specific to the entire send that will be carried along with the email and its activity data.
   Substitutions are not made on custom arguments within SendGrid.
   The combined total size of these custom arguments may not exceed 10,000 bytes.
+  Custom args must be a `String.t`.
 
   ## Example
 
@@ -27,10 +28,14 @@ defmodule Bamboo.SendGridHelper do
       |> with_custom_args("userId", "12345")
   """
   def with_custom_args(email, arg_name, arg_value) do
-    custom_args = Map.get(email.private, @custom_args, %{})
-    |> Map.put(arg_name, arg_value)
-    email
-    |> Email.put_private(@custom_args, custom_args)
+    if is_binary(arg_name) and is_binary(arg_value) do
+      custom_args = Map.get(email.private, @custom_args, %{})
+      |> Map.put(arg_name, arg_value)
+      email
+      |> Email.put_private(@custom_args, custom_args)
+    else
+      raise "expected the both arg_name and arg_value parameters to be of type binary, got #{arg_name}:#{arg_value}"
+    end
   end
 
   @doc """

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -4,9 +4,15 @@ defmodule Bamboo.SendGridHelperTest do
   import Bamboo.SendGridHelper
 
   @template_id "80509523-83de-42b6-a2bf-54b7513bd2aa"
-
+  @custom_user_arg {"userId", "123"}
   setup do
     {:ok, email: Bamboo.Email.new_email()}
+  end
+
+  test "with_custom_args/3 adds the correct property", %{email: email} do
+    email = email |> with_custom_args(elem(@custom_user_arg, 0), elem(@custom_user_arg, 1))
+    assert email.private[:custom_args] != nil
+    assert email.private[:custom_args][elem(@custom_user_arg, 0)] == elem(@custom_user_arg, 1)
   end
 
   test "with_template/2 adds the correct template", %{email: email} do

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -15,6 +15,18 @@ defmodule Bamboo.SendGridHelperTest do
     assert email.private[:custom_args][elem(@custom_user_arg, 0)] == elem(@custom_user_arg, 1)
   end
 
+  test "with_custom_args/3 raises on non-string arg_name", %{email: email} do
+    assert_raise RuntimeError, fn ->
+      email |> with_custom_args(123, elem(@custom_user_arg, 1))
+    end
+  end
+
+  test "with_custom_args/3 raises on non-string arg_value", %{email: email} do
+    assert_raise RuntimeError, fn ->
+      email |> with_custom_args(elem(@custom_user_arg, 0), 123)
+    end
+  end
+
   test "with_template/2 adds the correct template", %{email: email} do
     email = email |> with_template(@template_id)
     assert email.private[:send_grid_template] == %{template_id: @template_id}


### PR DESCRIPTION
This PR adds top level custom args support to the sendgrid adapter as mentioned in https://github.com/thoughtbot/bamboo/issues/331


