### PR TITLE
sendgrid substitution should send strings not array

### DIFF
--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -62,8 +62,8 @@ defmodule Bamboo.SendGridHelper do
 
   defp add_substitution(template, tag, value) do
     template
-    |> Map.update(:substitutions, %{tag => [value]}, fn substitutions ->
-      Map.merge(substitutions, %{tag => [value]})
+    |> Map.update(:substitutions, %{tag => value}, fn substitutions ->
+      Map.merge(substitutions, %{tag => value})
     end)
   end
 end

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -141,7 +141,7 @@ defmodule Bamboo.SendGridAdapterTest do
     personalization = List.first(params["personalizations"])
     assert params["content"] == [%{"type" => "text/plain", "value" => " "}]
     assert params["template_id"] == "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
-    assert personalization["substitutions"] == %{"%foo%" => ["bar"]}
+    assert personalization["substitutions"] == %{"%foo%" => "bar"}
   end
 
   test "deliver/2 correctly formats reply-to from headers" do

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -30,8 +30,8 @@ defmodule Bamboo.SendGridHelperTest do
     email = email |> substitute("%name%", "Jon Snow") |> substitute("%location%", "Westeros")
     assert email.private[:send_grid_template] == %{
         substitutions: %{
-          "%name%" => ["Jon Snow"],
-          "%location%" => ["Westeros"]
+          "%name%" => "Jon Snow",
+          "%location%" => "Westeros"
         }
       }
   end
@@ -47,7 +47,7 @@ defmodule Bamboo.SendGridHelperTest do
     assert email.private[:send_grid_template] == %{
       template_id: @template_id,
       substitutions: %{
-        "%name%" => ["Jon Snow"]
+        "%name%" => "Jon Snow"
       }
     }
   end


### PR DESCRIPTION
According to the documentation the substitutions should be `A collection of key/value pairs following the pattern "substitution_tag":"value to substitute". All are assumed to be strings.`

I was receiving a cryptic error response from the SendGrid api when using the latest code from Master.

More details in https://github.com/thoughtbot/bamboo/issues/333