### PR TITLE
Fix SendGrid templates for API v3

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -132,7 +132,12 @@ defmodule Bamboo.SendGridAdapter do
   defp put_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
   defp put_content(body, email) do
-    Map.put(body, :content, content(email))
+    email_content = content(email)
+    if not Enum.empty?(email_content) do
+      Map.put(body, :content, content(email))
+    else
+      body
+    end
   end
 
   defp content(email) do
@@ -151,14 +156,8 @@ defmodule Bamboo.SendGridAdapter do
     [%{type: "text/plain", value: text_body} | list]
   end
 
-  defp put_template_id(body, %Email{private: %{send_grid_template: %{template_id: template_id}}} = email) do
-    # SendGrid will error with empty content and subject, even while using templates.
-    # Sets default `text_body` and `subject` if neither are specified,
-    # allowing the consumer to neglect doing so themselves.
-    body
-    |> ensure_content_provided(email)
-    |> ensure_subject_provided(email)
-    |> Map.put(:template_id, template_id)
+  defp put_template_id(body, %Email{private: %{send_grid_template: %{template_id: template_id}}}) do
+    Map.put(body, :template_id, template_id)
   end
   defp put_template_id(body, _), do: body
 
@@ -180,16 +179,6 @@ defmodule Bamboo.SendGridAdapter do
     end)
     Map.put(body, :attachments, transformed)
   end
-
-  defp ensure_content_provided(%{content: []} = body, email) do
-    put_content(body, %Email{email | text_body: " "})
-  end
-  defp ensure_content_provided(body, _), do: body
-
-  defp ensure_subject_provided(%{subject: nil} = body, email) do
-    put_subject(body, %Email{email | subject: " "})
-  end
-  defp ensure_subject_provided(body, _), do: body
 
   defp put_addresses(body, _, []), do: body
   defp put_addresses(body, field, addresses), do: Map.put(body, field, Enum.map(addresses, &to_address/1))

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -129,7 +129,8 @@ defmodule Bamboo.SendGridAdapter do
   end
   defp put_reply_to(body, _), do: body
 
-  defp put_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
+  defp put_subject(body, %Email{subject: subject}) when not is_nil(subject), do: Map.put(body, :subject, subject)
+  defp put_subject(body, _), do: body
 
   defp put_content(body, email) do
     email_content = content(email)

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -62,8 +62,8 @@ defmodule Bamboo.SendGridHelper do
 
   defp add_substitution(template, tag, value) do
     template
-    |> Map.update(:substitutions, %{tag => [value]}, fn substitutions ->
-      Map.merge(substitutions, %{tag => [value]})
+    |> Map.update(:substitutions, %{tag => value}, fn substitutions ->
+      Map.merge(substitutions, %{tag => value})
     end)
   end
 end

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -139,7 +139,7 @@ defmodule Bamboo.SendGridAdapterTest do
 
     assert_receive {:fake_sendgrid, %{params: params}}
     personalization = List.first(params["personalizations"])
-    assert params["content"] == [%{"type" => "text/plain", "value" => " "}]
+    refute Map.has_key?(params, "content")
     assert params["template_id"] == "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
     assert personalization["substitutions"] == %{"%foo%" => ["bar"]}
   end

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -141,7 +141,7 @@ defmodule Bamboo.SendGridAdapterTest do
     personalization = List.first(params["personalizations"])
     refute Map.has_key?(params, "content")
     assert params["template_id"] == "a4ca8ac9-3294-4eaf-8edc-335935192b8d"
-    assert personalization["substitutions"] == %{"%foo%" => ["bar"]}
+    assert personalization["substitutions"] == %{"%foo%" => "bar"}
   end
 
   test "deliver/2 doesn't force a subject" do

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -144,6 +144,18 @@ defmodule Bamboo.SendGridAdapterTest do
     assert personalization["substitutions"] == %{"%foo%" => ["bar"]}
   end
 
+  test "deliver/2 doesn't force a subject" do
+    email = new_email(
+      from: {"From", "from@foo.com"},
+    )
+
+    email
+    |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    refute Map.has_key?(params, "subject")
+  end
+
   test "deliver/2 correctly formats reply-to from headers" do
     email = new_email(headers: %{"reply-to" => "foo@bar.com"})
 

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -30,8 +30,8 @@ defmodule Bamboo.SendGridHelperTest do
     email = email |> substitute("%name%", "Jon Snow") |> substitute("%location%", "Westeros")
     assert email.private[:send_grid_template] == %{
         substitutions: %{
-          "%name%" => ["Jon Snow"],
-          "%location%" => ["Westeros"]
+          "%name%" => "Jon Snow",
+          "%location%" => "Westeros"
         }
       }
   end
@@ -47,7 +47,7 @@ defmodule Bamboo.SendGridHelperTest do
     assert email.private[:send_grid_template] == %{
       template_id: @template_id,
       substitutions: %{
-        "%name%" => ["Jon Snow"]
+        "%name%" => "Jon Snow"
       }
     }
   end


### PR DESCRIPTION
The SendGridAdapter forces content and subject for template-only SendGrid API requests. When using the recent master (we need attachments), HTML emails are completely broken. This only happens when having `{"content": [{"type": "text/plain", "value": " "}]}` in the API post request.

The error explained in the comment only happens when the transmitted content is an empty array - it doesn't occur if no content key appears at all.

I only ran the tests and did some testing with our SendGrid template setup, so maybe someone can also test non-template SendGrid requests (although I don't see why there should be any problem with those)