### PR TITLE
added support for categories and supporting tests

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -92,6 +92,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_content(email)
     |> put_template_id(email)
     |> put_attachments(email)
+    |> put_categories(email)
   end
 
   defp put_from(body, %Email{from: from}) do
@@ -166,6 +167,12 @@ defmodule Bamboo.SendGridAdapter do
     Map.put(body, :substitutions, substitutions)
   end
   defp put_template_substitutions(body, _), do: body
+
+  defp put_categories(body, %Email{private: %{categories: categories}}) when is_list(categories) and length(categories) <= 10 do
+    body
+    |> Map.put(:categories, categories)
+  end
+  defp put_categories(body, _), do: body
 
   defp put_attachments(body, %Email{attachments: []}), do: body
   defp put_attachments(body, %Email{attachments: attachments}) do

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -14,6 +14,7 @@ defmodule Bamboo.SendGridHelper do
 
   @id_size 36
   @field_name :send_grid_template
+  @categories :categories
 
   @doc """
   Specify the template for SendGrid to use for the context of the substitution
@@ -53,6 +54,26 @@ defmodule Bamboo.SendGridHelper do
     else
       raise "expected the tag parameter to be of type binary, got #{tag}"
     end
+  end
+
+  @doc """
+  An array of category names for this email. A maximum of 10 categories can be assigned to an email.
+  Duplicate categories will be ignored and only unique entries will be sent. 
+  
+  ## Example
+ 
+      email
+      |> with_categories("campaign-12345")
+  """
+  def with_categories(email, categories) when is_list(categories) do
+    categories = Map.get(email.private, @categories, []) ++ categories
+    |> MapSet.new
+    |> MapSet.to_list
+    email
+    |> Email.put_private(@categories, Enum.slice(categories, 0, 10))
+  end
+  def with_categories(email, categories) do
+    raise "expected a list of category strings"
   end
 
   defp set_template(template, template_id) do

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -57,4 +57,26 @@ defmodule Bamboo.SendGridHelperTest do
     email_2 = email |> substitute("%name%", "Jon Snow") |> with_template(@template_id)
     assert email_1 == email_2
   end
+
+  test "with_categories/2 adds the correct property", %{email: email} do
+    email = email |> with_categories(["category-1"])
+    assert email.private[:categories] != nil
+    assert is_list(email.private[:categories])
+    assert length(email.private[:categories]) == 1
+  end
+
+  test "with_categories/2 concatenates multiple lists", %{email: email} do
+    email = email |> with_categories(["category-1"]) |> with_categories(["category-2", "category-3"])
+    assert length(email.private[:categories]) == 3
+  end
+
+  test "with_categories/2 removes duplicate entries", %{email: email} do
+    email = email |> with_categories(["category-1"]) |> with_categories(["category-2", "category-1"])
+    assert length(email.private[:categories]) == 2
+  end
+
+  test "with_categories/2 only sends the first 10 entries", %{email: email} do
+    email = email |> with_categories(["category-1", "category-2", "category-3", "category-4", "category-5", "category-6", "category-7", "category-8", "category-9", "category-10", "category-11"])
+    assert length(email.private[:categories]) == 10
+  end
 end


### PR DESCRIPTION
This PR adds categories support to the sendgrid adapter as mentioned in #335