### PR TITLE
Fix collapsing html email preview

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -175,8 +175,8 @@
           <p class="email-detail-body">
             <script>
             function adjustFrameHeight(iframe) {
-              var body = iframe.contentWindow.document.body;
-              iframe.style.height = (body.scrollHeight + body.offsetHeight - body.clientHeight) + "px";
+              var contentWindow = iframe.contentWindow;
+              iframe.style.height = (contentWindow.outerHeight) + "px";
             }
             </script>
             <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>


### PR DESCRIPTION
In some cases, the css of an email may cause the `document.body.clientHeight` to report 0, which collapses the email preview iframe. Using `contentWindow.outerHeight` seems to work around
this issue. Fixes https://github.com/thoughtbot/bamboo/issues/350.