### PR TITLE
deliver/1 spec

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -79,7 +79,7 @@ defmodule Bamboo.Mailer do
 
       defp build_config, do: Bamboo.Mailer.build_config(__MODULE__, unquote(otp_app))
 
-      @spec deliver(Bamboo.Email.t) :: no_return()
+      @spec deliver(any()) :: no_return()
       def deliver(_email) do
         raise """
         you called deliver/1, but it has been renamed to deliver_now/1 to add clarity.


### PR DESCRIPTION
Change prepared `@spec deliver(any()) :: no_return()` because function ignore parameters (now only `Bamboo.Email.t` required).