### PR TITLE
Allow attachments in LocalAdapter

### DIFF
--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -43,6 +43,8 @@ defmodule Bamboo.LocalAdapter do
 
   def handle_config(config), do: config
 
+  def supports_attachments?, do: true
+
   defp open_url_in_browser(url) when is_binary(url) do
     case :os.type() do
       {:unix, :darwin} -> System.cmd("open", [url])


### PR DESCRIPTION
This allows local testing of emails with attachments.

A more full-featured PR would have the attachments show up in the `sent_emails` page.  I'm not sure what that should look like, or how much work it would be, but this PR at least avoids raising an exception when sending an e-mail with attachments when running in dev mode.