### PR TITLE
Allow sandbox mode for SendGrid adapter

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -16,6 +16,10 @@ defmodule Bamboo.SendGridAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.SendGridAdapter,
         api_key: "my_api_key" # or {:system, "SENDGRID_API_KEY"}
+        
+      # To enable sandbox mode (e.g. in development or staging environments),
+      # in config/dev.exs or config/prod.exs etc
+      config :my_app, MyApp.Mailer, sandbox: true
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -33,7 +33,7 @@ defmodule Bamboo.SendGridAdapter do
 
   def deliver(email, config) do
     api_key = get_key(config)
-    body = email |> to_sendgrid_body |> Poison.encode!
+    body = email |> to_sendgrid_body(config) |> Poison.encode!
     url = [base_uri(), @send_message_path]
 
     case :hackney.post(url, headers(api_key), body, [:with_body]) do
@@ -86,7 +86,7 @@ defmodule Bamboo.SendGridAdapter do
     ]
   end
 
-  defp to_sendgrid_body(%Email{} = email) do
+  defp to_sendgrid_body(%Email{} = email, config) do
     %{}
     |> put_from(email)
     |> put_personalization(email)
@@ -96,6 +96,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_template_id(email)
     |> put_attachments(email)
     |> put_categories(email)
+    |> put_settings(config)
   end
 
   defp put_from(body, %Email{from: from}) do
@@ -144,6 +145,9 @@ defmodule Bamboo.SendGridAdapter do
       body
     end
   end
+
+  defp put_settings(body, %{sandbox: true}), do: Map.put(body, :mail_settings, %{sandbox: true})
+  defp put_settings(body, _), do: body
 
   defp content(email) do
     []

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -6,6 +6,7 @@ defmodule Bamboo.SendGridAdapterTest do
   @config %{adapter: SendGridAdapter, api_key: "123_abc"}
   @config_with_bad_key %{adapter: SendGridAdapter, api_key: nil}
   @config_with_env_var_key %{adapter: SendGridAdapter, api_key: {:system, "SENDGRID_API"}}
+  @config_with_sandbox_enabled %{adapter: SendGridAdapter, api_key: "123_abc", sandbox: true}
 
   defmodule FakeSendgrid do
     use Plug.Router
@@ -192,6 +193,14 @@ defmodule Bamboo.SendGridAdapterTest do
 
     assert_receive {:fake_sendgrid, %{params: params}}
     refute Map.has_key?(params, "attachments")
+  end
+
+  test "deliver/2 will set sandbox mode correctly" do
+    email = new_email()
+    email |> SendGridAdapter.deliver(@config_with_sandbox_enabled)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["mail_settings"]["sandbox"] == true
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
Allows the configuration of the sandbox mode on SendGrid, ala #329 .

Use case:

We're running a staging and production Heroku app with SendGrid and a mirrored DB snapshot, we'd like to set sandbox mode on staging so we can see emails have gone to the send grid, but not been sent.