### PR TITLE
Unassign unused variables

### DIFF
--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -72,7 +72,7 @@ defmodule Bamboo.SendGridHelper do
     email
     |> Email.put_private(@categories, Enum.slice(categories, 0, 10))
   end
-  def with_categories(email, categories) do
+  def with_categories(_email, _categories) do
     raise "expected a list of category strings"
   end
 


### PR DESCRIPTION
This removes the compiler warnings.

I would love to find a way to get these warnings to break the build but unfortunately `Phoenix.View` is used in our modules but is not in the mix file (for good reason). This means that we can't run `mix compile --warnings-as-errors` successfully.

Once we move to Elixir 1.6, I believe the autoformatter will take care of those issues. Any ideas in the meantime?