### PR TITLE
Allow protocol impls to return a String.t

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -116,6 +116,7 @@ defmodule Bamboo.MailgunAdapter do
   defp prepare_recipient({nil, address}), do: address
   defp prepare_recipient({"", address}), do: address
   defp prepare_recipient({name, address}), do: "#{name} <#{address}>"
+  defp prepare_recipient(address) when is_binary(address), do: address
 
   defp put_subject(body, %Email{subject: subject}), do: Map.put(body, :subject, subject)
 
@@ -124,13 +125,13 @@ defmodule Bamboo.MailgunAdapter do
 
   defp put_html(body, %Email{html_body: nil}), do: body
   defp put_html(body, %Email{html_body: html_body}), do: Map.put(body, :html, html_body)
-  
+
   defp put_headers(body, %Email{headers: headers}) do
     Enum.reduce(headers, body, fn({key, value}, acc) ->
       Map.put(acc, :"h:#{key}", value)
     end)
   end
-  
+
   defp put_custom_vars(body, %Email{private: private}) do
     custom_vars = Map.get(private, :mailgun_custom_vars, %{})
 
@@ -156,10 +157,10 @@ defmodule Bamboo.MailgunAdapter do
        {"filename", ~s/"#{attachment.filename}"/}]},
      []}
   end
-  
+
   @mailgun_message_fields ~w(from to cc bcc subject text html)a
   @internal_fields ~w(attachments)a
-  
+
   def filter_non_empty_mailgun_fields(body) do
     Enum.filter(body, fn({key, value}) ->
       # Key is a well known mailgun field (including header and custom var field) and its value is not empty

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -16,7 +16,7 @@ defmodule Bamboo.SendGridAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.SendGridAdapter,
         api_key: "my_api_key" # or {:system, "SENDGRID_API_KEY"}
-        
+
       # To enable sandbox mode (e.g. in development or staging environments),
       # in config/dev.exs or config/prod.exs etc
       config :my_app, MyApp.Mailer, sandbox: true
@@ -205,6 +205,7 @@ defmodule Bamboo.SendGridAdapter do
   defp to_address({nil, address}), do: %{email: address}
   defp to_address({"", address}), do: %{email: address}
   defp to_address({name, address}), do: %{email: address, name: name}
+  defp to_address(address) when is_binary(address), do: %{email: address}
 
   defp base_uri do
     Application.get_env(:bamboo, :sendgrid_base_uri) || @default_base_uri

--- a/test/support/user_formatter.ex
+++ b/test/support/user_formatter.ex
@@ -3,6 +3,10 @@ defmodule Bamboo.Test.User do
 end
 
 defimpl Bamboo.Formatter, for: Bamboo.Test.User do
+  def format_email_address(%Bamboo.Test.User{first_name: nil, email: email}, _opts) do
+    email
+  end
+
   def format_email_address(user, %{type: :from}) do
     {"#{user.first_name} (MyApp)", user.email}
   end


### PR DESCRIPTION
The spec for `Bamboo.Formatter` says `format_email_address` should
return a `Bamboo.Email.address`, defined as `String.t | {String.t, String.t}`,
but returning a `String.t` didn't work with any of the adapters.

PS: There's some diff garbage because some whitespaces were removed, so it's easier to read with these ignored: https://github.com/thoughtbot/bamboo/pull/386/files?utf8=%E2%9C%93&diff=split&w=1 -- sorry about that.