### PR TITLE
Add .t() spec type to Bamboo.Attachment

### DIFF
--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -4,6 +4,13 @@ defmodule Bamboo.Attachment do
 
   defstruct filename: nil, content_type: nil, path: nil, data: nil
 
+  @type t() :: %__MODULE__{
+    path: nil | String.t(),
+    filename: nil | String.t(),
+    content_type: nil | String.t(),
+    data: nil | binary()
+  }
+
   @doc ~S"""
   Creates a new Attachment
 


### PR DESCRIPTION
**Changes**
* Added (probably) missing `.t()` type spec to `Bamboo.Attachment`.

---
**Description**
In most deps, prepared type for dialyzer's specs enables easier prepare own specs. I decided to insert this type also in Attachment module. In one of my project, I tried to use it, and I surprised when dialyzer return `type does not exist`.