### PR TITLE
In SentEmailViewer , show text template in a `<pre>` html tag

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -23,11 +23,6 @@ defmodule Bamboo.SentEmailViewerPlug.Helper do
   end
   def format_headers(values), do: inspect(values)
 
-  def format_text(nil), do: ""
-  def format_text(text_body) do
-    String.replace(text_body, "\n", "<br>")
-  end
-
   def format_email_address({nil, address}), do: address
   def format_email_address({name, address}) do
     "#{name}&lt;#{address}&gt;"

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -183,9 +183,9 @@
           </p>
 
           <h3 class="email-detail-body-label">Text Body</h3>
-          <p class="email-detail-body">
-            <%= Bamboo.SentEmailViewerPlug.Helper.format_text(@selected_email.text_body) %>
-          </p>
+          <pre class="email-detail-body">
+            <%= @selected_email.text_body %>
+          </pre>
         </section>
       </section>
     </main>


### PR DESCRIPTION
This make the whitespace being shown as it is in the text/plain template. Right now it differs quite a bit, if you use new lines and indents in various combinations.