### PR TITLE
Allow to use the complete API URL for the Mailgun adapter

### DIFF
--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -74,6 +74,26 @@ defmodule Bamboo.MailgunAdapterTest do
     end
   end
 
+  test "deliver/2 sends the email using the given url (complete)" do
+    base_uri = Application.get_env(:bamboo, :mailgun_base_uri)
+    config = Map.put(@config, :domain, "#{base_uri}/test.tt/messages")
+    new_email() |> MailgunAdapter.deliver(config)
+
+    assert_receive {:fake_mailgun, %{request_path: request_path}}
+
+    assert request_path == "/test.tt/messages"
+  end
+
+  test "deliver/2 sends the email adding the suffix /messages to the given url" do
+    base_uri = Application.get_env(:bamboo, :mailgun_base_uri)
+    config = Map.put(@config, :domain, "#{base_uri}/test.tt")
+    new_email() |> MailgunAdapter.deliver(config)
+
+    assert_receive {:fake_mailgun, %{request_path: request_path}}
+
+    assert request_path == "/test.tt/messages"
+  end
+
   test "deliver/2 sends the to the right url" do
     new_email() |> MailgunAdapter.deliver(@config)
 


### PR DESCRIPTION
This commit allows to use the complete API URL instead of your domain for the
Mailgun adapter.

When I was trying to use this adapter for the first time I tried to follow the
same pattern as in `curl`:

```
curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
https://api.mailgun.net/v3/samples.mailgun.org/messages \
 -F from='Excited User <excited@samples.mailgun.org>' \
 -F to='devs@mailgun.net' \
 -F subject='Hello' \
 -F text='Testing some Mailgun awesomeness!'
```

It was a mistake trying to do this, but the current implementation do not emit
any warning about this. So, instead of emit a warning I added support for
passing the complete API URL instead of the domain.