### PR TITLE
[Fix #343] Use list of tuple instead of Map for headers

### DIFF
--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -97,7 +97,7 @@ defmodule Bamboo.MandrillAdapter do
       subject: email.subject,
       text: email.text_body,
       html: email.html_body,
-      headers: email.headers,
+      headers: email.headers |> Enum.into(%{}),
       attachments: attachments(email)
     }
     |> add_message_params(email)

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -73,7 +73,7 @@ defmodule Bamboo.Email do
           subject: nil | String.t(),
           html_body: nil | String.t(),
           text_body: nil | String.t(),
-          headers: %{String.t() => String.t()},
+          headers: [{String.t(), String.t()}],
           assigns: %{atom => any},
           private: %{atom => any}
         }
@@ -85,7 +85,7 @@ defmodule Bamboo.Email do
             subject: nil,
             html_body: nil,
             text_body: nil,
-            headers: %{},
+            headers: [],
             attachments: [],
             assigns: %{},
             private: %{}
@@ -182,7 +182,7 @@ defmodule Bamboo.Email do
   """
   @spec put_header(__MODULE__.t(), String.t(), String.t()) :: __MODULE__.t()
   def put_header(%__MODULE__{headers: headers} = email, header_name, value) do
-    %{email | headers: Map.put(headers, header_name, value)}
+    %{email | headers: [{header_name, value} | headers]}
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Bamboo.Mixfile do
   def project do
     [
       app: :bamboo,
-      version: "1.1.0",
+      version: "2.0.0",
       elixir: "~> 1.2",
       source_url: @project_url,
       homepage_url: @project_url,

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -176,7 +176,7 @@ defmodule Bamboo.MailgunAdapterTest do
         text_body: "TEXT BODY",
         html_body: "HTML BODY"
       )
-      |> Email.put_header("reply-to", "random@foo.com")
+      |> Email.put_header("Reply-To", "random@foo.com")
 
     MailgunAdapter.deliver(email, @config)
 

--- a/test/lib/bamboo/adapters/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mandrill_adapter_test.exs
@@ -118,7 +118,7 @@ defmodule Bamboo.MandrillAdapterTest do
     assert message["subject"] == email.subject
     assert message["text"] == email.text_body
     assert message["html"] == email.html_body
-    assert message["headers"] == email.headers
+    assert message["headers"] == email.headers |> Enum.into(%{})
 
     assert message["attachments"] == [
              %{

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -12,7 +12,7 @@ defmodule Bamboo.EmailTest do
              subject: nil,
              html_body: nil,
              text_body: nil,
-             headers: %{}
+             headers: []
            }
   end
 
@@ -70,7 +70,7 @@ defmodule Bamboo.EmailTest do
     assert email.cc == "cc@example.com"
     assert email.bcc == "bcc@foo.com"
     assert email.subject == "Flexible Emails"
-    assert email.headers["Reply-To"] == "reply@foo.com"
+    assert {"Reply-To", "reply@foo.com"} in email.headers
   end
 
   test "put_private/3 puts a key and value in the private attribute" do


### PR DESCRIPTION
Mostly changed for Mailgun adapter, not sure whether Mandrill supports this.

Just an initial attempt.