### PR TITLE
lazily render debug logs

### DIFF
--- a/lib/bamboo.ex
+++ b/lib/bamboo.ex
@@ -23,7 +23,7 @@ defmodule Bamboo do
       message = """
       All recipients were set to nil. Must specify at least one recipient.
 
-      Full email - #{inspect(email, limit: :infinity)}
+      Full email - #{inspect(email, limit: 150)}
       """
 
       %NilRecipientsError{message: message}

--- a/lib/bamboo/api_error.ex
+++ b/lib/bamboo/api_error.ex
@@ -47,11 +47,11 @@ defmodule Bamboo.ApiError do
 
     Here is the response:
 
-    #{inspect(response, limit: :infinity)}
+    #{inspect(response, limit: 150)}
 
     Here are the params we sent:
 
-    #{inspect(params, limit: :infinity)}
+    #{inspect(params, limit: 150)}
     """
 
     message =

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -141,19 +141,23 @@ defmodule Bamboo.Mailer do
   end
 
   defp debug_sent(email, adapter) do
-    Logger.debug("""
-    Sending email with #{inspect(adapter)}:
+    Logger.debug(fn ->
+      """
+      Sending email with #{inspect(adapter)}:
 
-    #{inspect(email, limit: :infinity)}
-    """)
+      #{inspect(email, limit: :infinity)}
+      """
+    end)
   end
 
   defp debug_unsent(email) do
-    Logger.debug("""
-    Email was not sent because recipients are empty.
+    Logger.debug(fn ->
+      """
+      Email was not sent because recipients are empty.
 
-    Full email - #{inspect(email, limit: :infinity)}
-    """)
+      Full email - #{inspect(email, limit: :infinity)}
+      """
+    end)
   end
 
   defp validate_and_normalize(email, adapter) do

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -145,7 +145,7 @@ defmodule Bamboo.Mailer do
       """
       Sending email with #{inspect(adapter)}:
 
-      #{inspect(email, limit: :infinity)}
+      #{inspect(email, limit: 150)}
       """
     end)
   end
@@ -155,7 +155,7 @@ defmodule Bamboo.Mailer do
       """
       Email was not sent because recipients are empty.
 
-      Full email - #{inspect(email, limit: :infinity)}
+      Full email - #{inspect(email, limit: 150)}
       """
     end)
   end


### PR DESCRIPTION
In our app, we had some emails that were spending a massive amount of time sending, about 50-60 seconds _after_ the email contents had already been generated. This corresponded with crazy memory and CPU usage.

As a disclaimer, our app has some bad issues with excessive preloads that we are working on fixing. But where that data loading takes a few seconds, sending the email itself was taking an additional minute. It took me some digging to find out that the delay was happening between the call to our mailer and the adapter.

Without this change, `inspect()` is called for every email, regardless of the log level. After this change, `inspect()` only gets called if the log level is `:debug`.

Two additional concerns I wanted to discuss:

1. The reason this is such an issue is because `:assigns` are passed along as part of the `%Email{}` even after rendering has completed. This is why `inspect()` is so expensive, because we have a lot of nesting of data structs that are being inspected and logged. Is there any reason that `deliver_now()` and `deliver_later()` couldn't strip the `:assigns` from the `Email` before doing anything extra with them? Since the email has already rendered at this point, it doesn't seem like they serve much purpose.
2. Do we need to have the hardcoded `limit: :infinity` [as part of the debug call](https://github.com/thoughtbot/bamboo/blob/2805612f30f86342860c0ac3a09f163f5522cb40/lib/bamboo/mailer.ex#L147)? That turns this into a potentially severe issue, whereas it normally might not matter much if just part of a deeply nested dataset is logged.