### PR TITLE
Fix sendgrid sandbox mode

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -161,7 +161,9 @@ defmodule Bamboo.SendGridAdapter do
     end
   end
 
-  defp put_settings(body, %{sandbox: true}), do: Map.put(body, :mail_settings, %{sandbox: true})
+  defp put_settings(body, %{sandbox: true}),
+    do: Map.put(body, :mail_settings, %{sandbox_mode: %{enable: true}})
+
   defp put_settings(body, _), do: body
 
   defp content(email) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Bamboo.Mixfile do
   def project do
     [
       app: :bamboo,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.2",
       source_url: @project_url,
       homepage_url: @project_url,

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -230,7 +230,7 @@ defmodule Bamboo.SendGridAdapterTest do
     email |> SendGridAdapter.deliver(@config_with_sandbox_enabled)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["mail_settings"]["sandbox"] == true
+    assert params["mail_settings"]["sandbox_mode"]["enable"] == true
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
This pull request fix the SendGrid mail_settings when enable the sandbox config.

The sendgrid documentation enforces this format to enable sandbox mode:
```
"mail_settings": {
  "sandbox_mode": {
    "enable": true
  }
}
```

Bamboo currently build the settings as:
```
"mail_settings": {
  "sandbox":  true
}
```

References: 
 * https://sendgrid.com/docs/for-developers/sending-email/sandbox-mode/
 * https://github.com/thoughtbot/bamboo/pull/367#issuecomment-417705221