### PR TITLE
Issue 409 return value from adapter

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Bamboo.Mixfile do
   def project do
     [
       app: :bamboo,
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.2",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
Addresses [#409]. 

Returns the value from the Adapter rather than the Email struct. This can be important in the case of transactional email senders (for example Mandrill and Sendgrid) where you want/need to store the id generated by the underlying adapter service. 