### PR TITLE
Conditionally include the adapter response in deliver_now

### DIFF
--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -75,7 +75,8 @@ defmodule Bamboo.Email do
           text_body: nil | String.t(),
           headers: %{String.t() => String.t()},
           assigns: %{atom => any},
-          private: %{atom => any}
+          private: %{atom => any},
+          response: nil | %{atom => any}
         }
 
   defstruct from: nil,
@@ -88,7 +89,8 @@ defmodule Bamboo.Email do
             headers: %{},
             attachments: [],
             assigns: %{},
-            private: %{}
+            private: %{},
+            response: nil
 
   alias Bamboo.{Email, Attachment}
 

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -118,12 +118,12 @@ defmodule Bamboo.Mailer do
 
     if email.to == [] && email.cc == [] && email.bcc == [] do
       debug_unsent(email)
+      email
     else
       debug_sent(email, adapter)
-      adapter.deliver(email, config)
+      response = adapter.deliver(email, config)
+      maybe_merge_response(email, response)
     end
-
-    email
   end
 
   @doc false
@@ -139,6 +139,12 @@ defmodule Bamboo.Mailer do
 
     email
   end
+
+  defp maybe_merge_response(email, %{status_code: _, headers: _, body: _} = response) do
+    %{email | response: response}
+  end
+
+  defp maybe_merge_response(email, _), do: email
 
   defp debug_sent(email, adapter) do
     Logger.debug(fn ->


### PR DESCRIPTION
Resolves #451 and #161.

The email adapters return data about the results from sending the email when `.deliver` is called, some of which can be valuable but is not currently being captured. 

This introduces a change to merge that response in to the `Email` struct that is returned from `.deliver_now` if the response conforms to our norm of returning a status_code, headers, and body. (See the return for the success case from the adapters' `deliver` function for [SendGrid](https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/adapters/send_grid_adapter.ex#L49), [Mandrill](https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/adapters/mandrill_adapter.ex#L41), and [Mailgun](https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/adapters/mailgun_adapter.ex#L58).) If the return value does not conform to that pattern, nothing additional happens, so for example the results from `.deliver_now ` for the `LocalAdapter` and `TestAdapter` do not change. 

In looking at the custom adapters, it looks like some of them conform to this pattern, so they would get the response included now, and others do not and some have separate custom handling for their responses, so there would be no change for them. 

My goal was to include this data but to change as little as possible. I took inspiration from #308 and #450, but was opting not to change the type of what is returned from `deliver` or introduce a separate function for this.