### PR TITLE
Add API endpoints to EmailPreviewPlug

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -39,4 +39,14 @@ defmodule Bamboo.SentEmailViewerPlug.Helper do
   def format_email_address({name, address}) do
     "#{name}&lt;#{address}&gt;"
   end
+
+  def format_json_email(email) do
+    email
+    |> Map.update(:from, nil, &format_json_email_address/1)
+    |> Map.take([:to, :cc, :bcc, :subject, :text_body, :html_body, :headers, :attachments])
+  end
+
+  defp format_json_email_address({name, address}) do
+    [name, address]
+  end
 end

--- a/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
+++ b/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
@@ -190,6 +190,34 @@ defmodule Bamboo.SentEmailViewerPlugTest do
     assert conn.resp_body =~ "Email not found"
   end
 
+  test "list emails over API" do
+    normalize_and_push_pair(:html_email)
+    conn = conn(:get, "/api/all.json")
+
+    conn = AppRouter.call(conn, nil)
+
+    assert conn.status == 200
+    assert {"content-type", "application/json; charset=utf-8"} in conn.resp_headers
+
+    json = Bamboo.json_library().decode!(conn.resp_body)
+
+    first_email = json |> Enum.at(0)
+    assert first_email["html_body"] == "<p>ohai!</p>"
+  end
+
+  test "reset emails over API" do
+    normalize_and_push_pair(:html_email)
+    conn = conn(:post, "/api/reset.json")
+
+    conn = AppRouter.call(conn, nil)
+
+    assert conn.status == 200
+    assert {"content-type", "application/json; charset=utf-8"} in conn.resp_headers
+
+    json = Bamboo.json_library().decode!(conn.resp_body)
+    assert json == %{"ok" => true}
+  end
+
   defp newest_email do
     SentEmail.all() |> List.first()
   end


### PR DESCRIPTION
It's useful to be able to access the emails sent by the application code from integration tests. This PR exposes two new endpoints for listing and resetting the sent emails. Let me know if you've got any concerns or thoughts. Thanks!