### PR TITLE
Fix typos and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
 
 ### Fixes/Enhancements
 
-* Make JSON library configurable (https://github.com/thoughtbot/bamboo/374)
+* Make JSON library configurable (https://github.com/thoughtbot/bamboo/pull/374)
 * Fix reply-to header being set as string for mailgun adapter (https://github.com/thoughtbot/bamboo/pull/421)
-* Fix HTML escaping in headers (https://github.com/thoughtbot/bamboo/437)
-* Fix Sendgrid sandbox mode (https://github.com/thoughtbot/bamboo/442)
-* Lazily render debug logs (https://github.com/thoughtbot/bamboo/438)
+* Fix HTML escaping in headers (https://github.com/thoughtbot/bamboo/pull/437)
+* Fix Sendgrid sandbox mode (https://github.com/thoughtbot/bamboo/pull/442)
+* Lazily render debug logs (https://github.com/thoughtbot/bamboo/pull/438)
 
 ## [1.1.0] - 2018-08-15
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Flexible and easy to use email for Elixir.
 
 - **Adapter based** so it can be used with Mandrill, SMTP, or whatever else you want. Comes with a Mandrill adapter out of the box.
-- **Deliver emails in the background**. Most of the time you don't want or need to wait for the email to send. Bamboo makes it easy with Mailer.deliver_later
+- **Deliver emails in the background**. Most of the time you don't want or need to wait for the email to send. Bamboo makes it easy with Mailer.deliver_later.
 - **Easy to format recipients**. You can do `new_email(to: Repo.one(User))` and Bamboo can format the User struct if you implement Bamboo.Formatter.
 - **Works out of the box with Phoenix**. Use views and layouts to make rendering email easy.
 - **Very composable**. Emails are just a Bamboo.Email struct and can be manipulated with plain functions.
@@ -117,7 +117,7 @@ defmodule MyApp.Email do
     )
 
     # or pipe using Bamboo.Email functions
-    new_email
+    new_email()
     |> to("foo@example.com")
     |> from("me@example.com")
     |> subject("Welcome!!!")
@@ -152,7 +152,7 @@ defmodule MyApp.Email do
   import Bamboo.Phoenix
 
   def welcome_email do
-    base_email
+    base_email()
     |> to("foo@bar.com")
     |> subject("Welcome!!!")
     |> put_header("Reply-To", "someone@example.com")
@@ -162,7 +162,7 @@ defmodule MyApp.Email do
 
   defp base_email do
     # Here you can set a default from, default headers, etc.
-    new_email
+    new_email()
     |> from("myapp@example.com")
     |> put_html_layout({MyApp.LayoutView, "email.html"})
     |> put_text_layout({MyApp.LayoutView, "email.text"})
@@ -195,7 +195,7 @@ See the [Bamboo.Email] and [Bamboo.Formatter docs] for more info and examples.
 
 Phoenix is not required to use Bamboo. However, if you do use Phoenix, you can
 use Phoenix views and layouts with Bamboo. See
-[Bamboo.Phoenix](https://hexdocs.pm/bamboo/Bamboo.Phoenix.html)
+[Bamboo.Phoenix](https://hexdocs.pm/bamboo/Bamboo.Phoenix.html).
 
 ## Viewing Sent Emails
 
@@ -203,7 +203,7 @@ Bamboo comes with a handy plug for viewing emails sent in development. Now you
 don't have to look at the logs to get password resets, confirmation links, etc.
 Just open up the sent email viewer and click the link.
 
-See [Bamboo.SentEmailViewerPlug](https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html)
+See [Bamboo.SentEmailViewerPlug](https://hexdocs.pm/bamboo/Bamboo.SentEmailViewerPlug.html).
 
 Here is what it looks like:
 

--- a/README.md
+++ b/README.md
@@ -241,13 +241,13 @@ You can use the Bamboo.TestAdapter along with [Bamboo.Test] to make testing your
 emails straightforward.
 
 ```elixir
-# Using the mailer from the Getting Started section
-defmodule MyApp.Registration do
+defmodule MyApp.RegistrationTest do
   use ExUnit.Case
   use Bamboo.Test
+  alias MyApp.Email
 
+  # Unit testing is easy since the email is just a struct
   test "welcome email" do
-    # Unit testing is easy since the email is just a struct
     user = new_user
 
     email = Email.welcome_email(user)
@@ -257,13 +257,13 @@ defmodule MyApp.Registration do
     assert email.html_body =~ "Thanks for joining"
   end
 
+  # Integration test with the helpers from Bamboo.Test
   test "after registering, the user gets a welcome email" do
-    # Integration test with the helpers from Bamboo.Test
     user = new_user
 
-    MyApp.Register(user)
+    MyApp.Registration.create(user)
 
-    assert_delivered_email MyApp.Email.welcome_email(user)
+    assert_delivered_email Email.welcome_email(user)
   end
 end
 ```

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -177,7 +177,7 @@ defmodule Bamboo.MailgunAdapter do
     {
       :multipart,
       # Drop the remaining non-Mailgun fields
-      # Append the attachement parts
+      # Append the attachment parts
       body
       |> Map.drop(@internal_fields)
       |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)

--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -37,14 +37,14 @@ defmodule Bamboo.MandrillHelper do
   end
 
   @doc """
-  Set merge_vars that are used by Mandrill 
+  Set merge_vars that are used by Mandrill
 
   ## Example
 
       email
       |> put_merge_vars(users, fn(user) -> %{first_name: user.first_name} end)
 
-  A convenience function for: 
+  A convenience function for:
 
       email
       |> put_param(email, "merge_vars", [
@@ -108,7 +108,7 @@ defmodule Bamboo.MandrillHelper do
   Send emails using Mandrill's template API.
 
   Setup Mandrill to send using a named template with template content. Use this
-  in conjuction with merge vars to offload template rendering to Mandrill. The
+  in conjunction with merge vars to offload template rendering to Mandrill. The
   template name specified here must match the template name stored in Mandrill.
   Mandrill's API docs for this can be found [here](https://www.mandrillapp.com/api/docs/messages.JSON.html#method=send-template).
 

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -96,7 +96,7 @@ defmodule Bamboo.SendGridHelper do
   ...
 
 
-  The tag can be of any type since SendGrid allows you to use Handelbars in its templates
+  The tag can be of any type since SendGrid allows you to use Handlebars in its templates
 
   ## Example
 

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -2,7 +2,7 @@ defmodule Bamboo.Email do
   @moduledoc """
   Contains functions for composing emails.
 
-  Bamboo separates composing emails from delivering them. This separation emails
+  Bamboo separates composing emails from delivering them. This separation makes emails
   easy to test and makes things like using a default layout, or a default from
   address easy to do. This module is for creating emails. To actually send them,
   use [Bamboo.Mailer](Bamboo.Mailer.html).

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -214,7 +214,7 @@ defmodule Bamboo.Email do
     def create(conn, params) do
       #...
       email
-      |> put_attachment(%Bamboo.Attachment{filname: "event.ics", data: "BEGIN:VCALENDAR..."})
+      |> put_attachment(%Bamboo.Attachment{filename: "event.ics", data: "BEGIN:VCALENDAR..."})
       #...
     end
   """

--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -197,7 +197,7 @@ defmodule Bamboo.Phoenix do
   end
 
   @doc """
-  Sets an assign for the email. These will be availabe when rendering the email
+  Sets an assign for the email. These will be available when rendering the email
   """
   def assign(%{assigns: assigns} = email, key, value) do
     %{email | assigns: Map.put(assigns, key, value)}

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -195,10 +195,10 @@ defmodule Bamboo.Test do
       import ExUnit.Assertions
       assert_receive({:delivered_email, email}, 100, Bamboo.Test.flunk_no_emails_received())
 
-      recieved_email_params = email |> Map.from_struct()
+      received_email_params = email |> Map.from_struct()
 
-      assert Enum.all?(email_params, fn {k, v} -> do_match(recieved_email_params[k], v) end),
-             Bamboo.Test.flunk_attributes_do_not_match(email_params, recieved_email_params)
+      assert Enum.all?(email_params, fn {k, v} -> do_match(received_email_params[k], v) end),
+             Bamboo.Test.flunk_attributes_do_not_match(email_params, received_email_params)
     end
   end
 

--- a/lib/mix/start_sent_email_viewer_task.ex
+++ b/lib/mix/start_sent_email_viewer_task.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Bamboo.StartSentEmailViewer do
 
   @moduledoc false
 
-  # This coud be used in the future by the public, but right now it's only
+  # This could be used in the future by the public, but right now it's only
   # suitable for development.
 
   def run(_) do

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -111,9 +111,9 @@ defmodule Bamboo.MailgunAdapterTest do
     assert {"authorization", "Basic #{hashed_token}"} in headers
   end
 
-  # We keep two seperate tests, with and without attachment, because the output produced by the adapter changes a lot. (MIME multipart body instead of URL-encoded form)
+  # We keep two separate tests, with and without attachment, because the output produced by the adapter changes a lot. (MIME multipart body instead of URL-encoded form)
   test "deliver/2 sends from, subject, text body, html body, headers, custom vars and attachment" do
-    attachement_source_path = Path.join(__DIR__, "../../../support/attachment.txt")
+    attachment_source_path = Path.join(__DIR__, "../../../support/attachment.txt")
 
     email =
       new_email(
@@ -125,7 +125,7 @@ defmodule Bamboo.MailgunAdapterTest do
       |> Email.put_header("Reply-To", "random@foo.com")
       |> Email.put_header("X-My-Header", "my_header_value")
       |> Email.put_private(:mailgun_custom_vars, %{my_custom_var: 42, other_custom_var: 43})
-      |> Email.put_attachment(attachement_source_path)
+      |> Email.put_attachment(attachment_source_path)
 
     MailgunAdapter.deliver(email, @config)
 
@@ -146,7 +146,7 @@ defmodule Bamboo.MailgunAdapterTest do
 
     assert content_type == "application/octet-stream"
     assert filename == "attachment.txt"
-    assert File.read!(download_path) == File.read!(attachement_source_path)
+    assert File.read!(download_path) == File.read!(attachment_source_path)
 
     hashed_token = Base.encode64("api:" <> @config.api_key)
     assert {"authorization", "Basic #{hashed_token}"} in headers

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -220,7 +220,7 @@ defmodule Bamboo.MailerTest do
     end
   end
 
-  test "raises if all receipients are nil" do
+  test "raises if all recipients are nil" do
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: nil, cc: nil, bcc: nil) |> FooMailer.deliver_now()
     end


### PR DESCRIPTION
Minor fixes including typos and updates to code examples in the README that came up as I was trying to follow along setting up Bamboo. 

Includes a typo fix for https://github.com/thoughtbot/bamboo/issues/449.
