### PR TITLE
Fix with_bypass_list_management

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -238,15 +238,13 @@ defmodule Bamboo.SendGridAdapter do
 
   defp put_bypass_list_management(body, %Email{private: %{bypass_list_management: enabled}})
        when is_boolean(enabled) do
-    value = if enabled, do: 1, else: 0
-
-    filters_map =
+    mail_settings =
       body
-      |> Map.get(:filters, %{})
-      |> Map.put(:bypass_list_management, %{settings: %{enable: value}})
+      |> Map.get(:mail_settings, %{})
+      |> Map.put(:bypass_list_management, %{enable: enabled})
 
     body
-    |> Map.put(:filters, filters_map)
+    |> Map.put(:mail_settings, mail_settings)
   end
 
   defp put_bypass_list_management(body, _), do: body

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -140,12 +140,8 @@ defmodule Bamboo.SendGridHelper do
   A boolean setting to instruct SendGrid to bypass list management for this
   email. If enabled, SendGrid will ignore any email supression (such as
   unsubscriptions, bounces, spam filters) for this email. This is useful for
-  emails that users must receive, such as Terms of Service updates, or
+  emails that all users must receive, such as Terms of Service updates, or
   password resets.
-
-  More details in the [SendGrid documentation][1].
-
-  [1]: https://sendgrid.com/docs/API_Reference/SMTP_API/apps.html#bypass_list_management)
 
   ## Example
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -225,7 +225,7 @@ defmodule Bamboo.SendGridAdapterTest do
     |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["filters"]["bypass_list_management"]["settings"]["enable"] == 1
+    assert params["mail_settings"]["bypass_list_management"]["enable"] == true
   end
 
   test "deliver/2 doesn't force a subject" do
@@ -261,6 +261,17 @@ defmodule Bamboo.SendGridAdapterTest do
 
     assert_receive {:fake_sendgrid, %{params: params}}
     assert params["mail_settings"]["sandbox_mode"]["enable"] == true
+  end
+
+  test "deliver/2 with sandbox mode enabled, does not overwrite other mail_settings" do
+    email = new_email()
+    email
+    |> Bamboo.SendGridHelper.with_bypass_list_management(true)
+    |> SendGridAdapter.deliver(@config_with_sandbox_enabled)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["mail_settings"]["sandbox_mode"]["enable"] == true
+    assert params["mail_settings"]["bypass_list_management"]["enable"] == true
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
@maymillerricci apologies, I used the wrong API spec to implement #458, so named the data structure wrong. And due to hiccup at this end, thought it was working fine in end to end testing! This is fixed now.