### PR TITLE
Add Elixir code formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.6
+      - image: circleci/elixir:1.8.1
         environment:
           MIX_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,5 +21,6 @@ jobs:
           key: mix-cache-{{ checksum "mix.lock" }}
           paths: "deps"
 
+      - run: mix format --check-formatted
       - run: mix test
       - run: MIX_ENV=prod mix compile

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 21.2
+elixir 1.8.1

--- a/README.md
+++ b/README.md
@@ -298,9 +298,14 @@ Once we've decided how to move forward with a pull request:
     $ cd bamboo
     $ mix deps.get
     $ mix test
+    $ mix format
 
 Once you've made your additions and `mix test` passes, go ahead and open a PR!
 
+We run the test suite as well as formatter checks on CI. Make sure you are using
+the Elixir version defined in the `.tool-versions` file to have consistent
+formatting with what's being run on CI.
+ 
 ## Thanks!
 
 Thanks to @mtwilliams for an early version of the `SendGridAdapter`.

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -34,7 +34,9 @@ defmodule Bamboo.MandrillAdapter do
 
     case :hackney.post(uri, headers(), params, [:with_body]) do
       {:ok, status, _headers, response} when status > 299 ->
-        filtered_params = params |> Bamboo.json_library().decode!() |> Map.put("key", "[FILTERED]")
+        filtered_params =
+          params |> Bamboo.json_library().decode!() |> Map.put("key", "[FILTERED]")
+
         raise_api_error(@service_name, response, filtered_params)
 
       {:ok, status, headers, response} ->

--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -4,12 +4,12 @@ defmodule Bamboo.Attachment do
 
   defstruct filename: nil, content_type: nil, path: nil, data: nil
 
-  @type t() :: %__MODULE__{
-    path: nil | String.t(),
-    filename: nil | String.t(),
-    content_type: nil | String.t(),
-    data: nil | binary()
-  }
+  @type t :: %__MODULE__{
+          path: nil | String.t(),
+          filename: nil | String.t(),
+          content_type: nil | String.t(),
+          data: nil | binary()
+        }
 
   @doc ~S"""
   Creates a new Attachment

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -4,8 +4,11 @@ defmodule Bamboo.MailgunAdapterTest do
   alias Bamboo.MailgunAdapter
 
   @config %{adapter: MailgunAdapter, api_key: "dummyapikey", domain: "test.tt"}
-  @config_with_env_var_key %{adapter: MailgunAdapter,
-    api_key: {:system, "MAILGUN_API_KEY"}, domain: {:system, "MAILGUN_DOMAIN"}}
+  @config_with_env_var_key %{
+    adapter: MailgunAdapter,
+    api_key: {:system, "MAILGUN_API_KEY"},
+    domain: {:system, "MAILGUN_DOMAIN"}
+  }
 
   defmodule FakeMailgun do
     use Plug.Router
@@ -98,11 +101,10 @@ defmodule Bamboo.MailgunAdapterTest do
 
     assert_raise ArgumentError, ~r/no api_key set/, fn ->
       MailgunAdapter.handle_config(@config_with_env_var_key)
-
     end
+
     System.delete_env("MAILGUN_DOMAIN")
   end
-
 
   test "raises if an invalid ENV var is used for the domain" do
     System.put_env("MAILGUN_API_KEY", "env_api_key")
@@ -113,8 +115,8 @@ defmodule Bamboo.MailgunAdapterTest do
 
     assert_raise ArgumentError, ~r/no domain set/, fn ->
       MailgunAdapter.handle_config(@config_with_env_var_key)
-
     end
+
     System.delete_env("MAILGUN_API_KEY")
   end
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -265,6 +265,7 @@ defmodule Bamboo.SendGridAdapterTest do
 
   test "deliver/2 with sandbox mode enabled, does not overwrite other mail_settings" do
     email = new_email()
+
     email
     |> Bamboo.SendGridHelper.with_bypass_list_management(true)
     |> SendGridAdapter.deliver(@config_with_sandbox_enabled)


### PR DESCRIPTION
This does the following to configure the Elixir code formatter for use here:
* adds a `.formatter` file so we can run `mix format` 
* adds all the changes from running `mix format`
* adds a `.tool-versions` file so contributors can use consistent versions of Erlang and Elixir
* bumps the Elixir version on CI to match
* adds the check for formatted files to run on CI
* adds info to the Contributing section of the README about formatting

