### PR TITLE
Clarify changes and test phases in mailer test

### DIFF
--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -2,193 +2,36 @@ defmodule Bamboo.MailerTest do
   use ExUnit.Case
   alias Bamboo.Email
 
-  defmodule FooAdapter do
-    def deliver(email, config) do
-      send(:mailer_test, {:deliver, email, config})
-    end
+  @mailer_config adapter: __MODULE__.DefaultAdapter, foo: :bar
+
+  setup context do
+    config =
+      Keyword.merge(@mailer_config, [adapter: context[:adapter]], fn
+        _, v, nil -> v
+        _, _, v -> v
+      end)
+
+    Application.put_env(:bamboo, __MODULE__.Mailer, config)
+    Process.register(self(), :mailer_test)
+    on_exit(fn -> Application.delete_env(:bamboo, __MODULE__.Mailer) end)
+    :ok
+  end
+
+  defmodule(Mailer, do: use(Bamboo.Mailer, otp_app: :bamboo))
+
+  defmodule DefaultAdapter do
+    def deliver(email, config), do: send(:mailer_test, {:deliver, email, config})
 
     def handle_config(config), do: config
 
     def supports_attachments?, do: true
   end
 
-  defmodule CustomConfigAdapter do
-    def deliver(email, config) do
-      send(:mailer_test, {:deliver, email, config})
-    end
-
-    def handle_config(config) do
-      config |> Map.put(:custom_key, "Set by the adapter")
-    end
-  end
-
-  defmodule AdapterWithoutAttachmentSupport do
-    def deliver(_email, _config) do
-      :noop
-    end
-
-    def handle_config(config), do: config
-  end
-
-  @custom_config adapter: CustomConfigAdapter, foo: :bar
-
-  Application.put_env(:bamboo, __MODULE__.CustomConfigMailer, @custom_config)
-
-  defmodule CustomConfigMailer do
-    use Bamboo.Mailer, otp_app: :bamboo
-  end
-
-  @mailer_config adapter: AdapterWithoutAttachmentSupport, foo: :bar
-
-  Application.put_env(:bamboo, __MODULE__.AdapterWithoutAttachmentSupportMailer, @mailer_config)
-
-  defmodule AdapterWithoutAttachmentSupportMailer do
-    use Bamboo.Mailer, otp_app: :bamboo
-  end
-
-  @mailer_config adapter: FooAdapter, foo: :bar
-
-  Application.put_env(:bamboo, __MODULE__.FooMailer, @mailer_config)
-
-  defmodule FooMailer do
-    use Bamboo.Mailer, otp_app: :bamboo
-  end
-
-  setup do
-    Process.register(self(), :mailer_test)
-    :ok
-  end
-
-  test "raise if adapter does not support attachments and attachments are sent" do
-    path = Path.join(__DIR__, "../../support/attachment.docx")
-    email = new_email(to: "foo@bar.com") |> Email.put_attachment(path)
-
-    assert_raise RuntimeError, ~r/does not support attachments/, fn ->
-      AdapterWithoutAttachmentSupportMailer.deliver_now(email)
-    end
-
-    assert_raise RuntimeError, ~r/does not support attachments/, fn ->
-      AdapterWithoutAttachmentSupportMailer.deliver_later(email)
-    end
-  end
-
-  test "does not raise if adapter supports attachments" do
-    path = Path.join(__DIR__, "../../support/attachment.docx")
-    email = new_email(to: "foo@bar.com") |> Email.put_attachment(path)
-
-    FooMailer.deliver_now(email)
-
-    assert_received {:deliver, _email, _config}
-  end
-
-  test "does not raise if no attachments are on the email" do
-    email = new_email(to: "foo@bar.com")
-    AdapterWithoutAttachmentSupportMailer.deliver_now(email)
-  end
-
-  test "uses adapter's handle_config/1 to customize or validate the config" do
-    email = new_email(to: "foo@bar.com")
-
-    CustomConfigMailer.deliver_now(email)
-
-    assert_received {:deliver, _email, config}
-    assert config.custom_key == "Set by the adapter"
-  end
-
-  test "sets a default deliver_later_strategy if none is set" do
-    email = new_email(to: "foo@bar.com")
-
-    FooMailer.deliver_now(email)
-
-    assert_received {:deliver, _email, config}
-    assert config.deliver_later_strategy == Bamboo.TaskSupervisorStrategy
-  end
-
-  test "deliver/1 raises a helpful error message" do
-    assert_raise RuntimeError, ~r/Use deliver_now/, fn ->
-      FooMailer.deliver(:anything)
-    end
-  end
-
-  test "deliver_now/1 calls the adapter with the email and config as a map" do
-    email = new_email(to: "foo@bar.com")
-
-    returned_email = FooMailer.deliver_now(email)
-
-    assert returned_email == Bamboo.Mailer.normalize_addresses(email)
-    assert_received {:deliver, %Bamboo.Email{}, config}
-
-    config_with_default_strategy =
-      Enum.into(@mailer_config, %{})
-      |> Map.put(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)
-
-    assert config == config_with_default_strategy
-  end
-
-  test "deliver_now/1 with no from address" do
-    assert_raise Bamboo.EmptyFromAddressError, fn ->
-      FooMailer.deliver_now(new_email(from: nil))
-    end
-
-    assert_raise Bamboo.EmptyFromAddressError, fn ->
-      FooMailer.deliver_now(new_email(from: {"foo", nil}))
-    end
-  end
-
-  test "deliver_now/1 with empty lists for recipients does not deliver email" do
-    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_now()
-    refute_received {:deliver, _, _}
-
-    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_now()
-    refute_received {:deliver, _, _}
-
-    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_now()
-    refute_received {:deliver, _, _}
-
-    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_now()
-    refute_received {:deliver, _, _}
-  end
-
-  test "deliver_later/1 with empty lists for recipients does not deliver email" do
-    new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_later()
-    refute_received {:deliver, _, _}
-
-    new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_later()
-    refute_received {:deliver, _, _}
-
-    new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_later()
-    refute_received {:deliver, _, _}
-
-    new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_later()
-    refute_received {:deliver, _, _}
-  end
-
-  test "deliver_later/1 calls deliver on the adapter" do
-    email = new_email()
-
-    FooMailer.deliver_later(email)
-
-    assert_receive {:deliver, delivered_email, _config}
-    assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
-  end
-
-  test "deliver_now/1 wraps the recipients in a list" do
-    address = {"Someone", "foo@bar.com"}
-    email = new_email(to: address, cc: address, bcc: address)
-
-    FooMailer.deliver_now(email)
-
-    assert_received {:deliver, delivered_email, _}
-    assert delivered_email.to == [address]
-    assert delivered_email.cc == [address]
-    assert delivered_email.bcc == [address]
-  end
-
   test "deliver_now/1 converts binary addresses to %{name: name, email: email}" do
     address = "foo@bar.com"
     email = new_email(from: address, to: address, cc: address, bcc: address)
 
-    FooMailer.deliver_now(email)
+    Mailer.deliver_now(email)
 
     converted_address = {nil, address}
     assert_received {:deliver, delivered_email, _}
@@ -202,7 +45,7 @@ defmodule Bamboo.MailerTest do
     user = %Bamboo.Test.User{first_name: "Paul", email: "foo@bar.com"}
     email = new_email(from: user, to: user, cc: user, bcc: user)
 
-    FooMailer.deliver_now(email)
+    Mailer.deliver_now(email)
 
     converted_recipient = {user.first_name, user.email}
     assert_received {:deliver, delivered_email, _}
@@ -212,32 +55,121 @@ defmodule Bamboo.MailerTest do
     assert delivered_email.bcc == [converted_recipient]
   end
 
+  test "deliver_later/1 calls deliver on the adapter" do
+    email = new_email()
+
+    Mailer.deliver_later(email)
+
+    assert_receive {:deliver, delivered_email, _config}
+    assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
+  end
+
+  test "deliver_now/1 wraps the recipients in a list" do
+    address = {"Someone", "foo@bar.com"}
+    email = new_email(to: address, cc: address, bcc: address)
+
+    Mailer.deliver_now(email)
+
+    assert_received {:deliver, delivered_email, _}
+    assert delivered_email.to == [address]
+    assert delivered_email.cc == [address]
+    assert delivered_email.bcc == [address]
+  end
+
+  test "sets a default deliver_later_strategy if none is set" do
+    email = new_email(to: "foo@bar.com")
+
+    Mailer.deliver_now(email)
+
+    assert_received {:deliver, _email, config}
+    assert config.deliver_later_strategy == Bamboo.TaskSupervisorStrategy
+  end
+
+  test "deliver_now/1 calls the adapter with the email and config as a map" do
+    email = new_email(to: "foo@bar.com")
+
+    expected_final_config =
+      @mailer_config
+      |> Enum.into(%{})
+      |> Map.put(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)
+
+    returned_email = Mailer.deliver_now(email)
+
+    assert returned_email == Bamboo.Mailer.normalize_addresses(email)
+    assert_received {:deliver, %Bamboo.Email{}, ^expected_final_config}
+  end
+
+  test "deliver/1 raises a helpful error message" do
+    assert_raise RuntimeError, ~r/Use deliver_now/, fn ->
+      Mailer.deliver(:anything)
+    end
+  end
+
+  test "deliver_now/1 with no from address raises an error" do
+    assert_raise Bamboo.EmptyFromAddressError, fn ->
+      Mailer.deliver_now(new_email(from: nil))
+    end
+
+    assert_raise Bamboo.EmptyFromAddressError, fn ->
+      Mailer.deliver_now(new_email(from: {"foo", nil}))
+    end
+  end
+
+  test "deliver_now/1 with empty lists for recipients does not deliver email" do
+    new_email(to: [], cc: [], bcc: []) |> Mailer.deliver_now()
+    refute_received {:deliver, _, _}
+
+    new_email(to: [], cc: nil, bcc: nil) |> Mailer.deliver_now()
+    refute_received {:deliver, _, _}
+
+    new_email(to: nil, cc: [], bcc: nil) |> Mailer.deliver_now()
+    refute_received {:deliver, _, _}
+
+    new_email(to: nil, cc: nil, bcc: []) |> Mailer.deliver_now()
+    refute_received {:deliver, _, _}
+  end
+
+  test "deliver_later/1 with empty lists for recipients does not deliver email" do
+    new_email(to: [], cc: [], bcc: []) |> Mailer.deliver_later()
+    refute_received {:deliver, _, _}
+
+    new_email(to: [], cc: nil, bcc: nil) |> Mailer.deliver_later()
+    refute_received {:deliver, _, _}
+
+    new_email(to: nil, cc: [], bcc: nil) |> Mailer.deliver_later()
+    refute_received {:deliver, _, _}
+
+    new_email(to: nil, cc: nil, bcc: []) |> Mailer.deliver_later()
+    refute_received {:deliver, _, _}
+  end
+
   test "raises an error if an address does not have a protocol implemented" do
     email = new_email(from: 1)
 
     assert_raise Protocol.UndefinedError, fn ->
-      FooMailer.deliver_now(email)
+      Mailer.deliver_now(email)
     end
   end
 
   test "raises if all recipients are nil" do
     assert_raise Bamboo.NilRecipientsError, fn ->
-      new_email(to: nil, cc: nil, bcc: nil) |> FooMailer.deliver_now()
+      new_email(to: nil, cc: nil, bcc: nil)
+      |> Mailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: {"foo", nil})
-      |> FooMailer.deliver_now()
+      |> Mailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: [{"foo", nil}])
-      |> FooMailer.deliver_now()
+      |> Mailer.deliver_now()
     end
 
     assert_raise Bamboo.NilRecipientsError, fn ->
       new_email(to: [nil])
-      |> FooMailer.deliver_now()
+      |> Mailer.deliver_now()
     end
   end
 
@@ -245,7 +177,7 @@ defmodule Bamboo.MailerTest do
     email = new_email(from: %{foo: :bar})
 
     assert_raise ArgumentError, fn ->
-      FooMailer.deliver_now(email)
+      Mailer.deliver_now(email)
     end
   end
 
@@ -258,6 +190,68 @@ defmodule Bamboo.MailerTest do
 
     assert_raise RuntimeError, ~r/cannot call Bamboo.Mailer/, fn ->
       Bamboo.Mailer.deliver_later(email)
+    end
+  end
+
+  describe "attachments" do
+    defmodule AdapterWithoutAttachmentSupport do
+      def deliver(_email, _config), do: :noop
+
+      def handle_config(config), do: config
+
+      def supports_attachments?, do: false
+    end
+
+    @tag adapter: AdapterWithoutAttachmentSupport
+    test "raise if adapter does not support attachments and attachments are sent" do
+      path = Path.join(__DIR__, "../../support/attachment.docx")
+      email = new_email(to: "foo@bar.com") |> Email.put_attachment(path)
+
+      assert_raise RuntimeError, ~r/does not support attachments/, fn ->
+        Mailer.deliver_now(email)
+      end
+
+      assert_raise RuntimeError, ~r/does not support attachments/, fn ->
+        Mailer.deliver_later(email)
+      end
+    end
+
+    @tag adapter: AdapterWithoutAttachmentSupport
+    test "does not raise if no attachments are on the email" do
+      email = new_email(to: "foo@bar.com")
+      Mailer.deliver_now(email)
+    end
+
+    @tag adapter: DefaultAdapter
+    test "does not raise if adapter supports attachments" do
+      path = Path.join(__DIR__, "../../support/attachment.docx")
+      email = new_email(to: "foo@bar.com") |> Email.put_attachment(path)
+
+      Mailer.deliver_now(email)
+
+      assert_received {:deliver, _email, _config}
+    end
+  end
+
+  describe "configuration" do
+    defmodule CustomConfigAdapter do
+      def deliver(email, config) do
+        send(:mailer_test, {:deliver, email, config})
+      end
+
+      def handle_config(config) do
+        config |> Map.put(:custom_key, "Set by the adapter")
+      end
+    end
+
+    @tag adapter: CustomConfigAdapter
+    test "uses adapter's handle_config/1 to customize or validate the config" do
+      email = new_email(to: "foo@bar.com")
+
+      Mailer.deliver_now(email)
+
+      assert_received {:deliver, _email, config}
+      assert config.custom_key == "Set by the adapter"
     end
   end
 


### PR DESCRIPTION
The variance between tests in the mailer test case all relate to the
changes in adapters and what those adapters support. Currently each
change in adapter includes a new mailer, a new config declaration, and a
new addition to the environment. As all of these changes are isolated
near the top of the file, it is less clear when reading tests lower in
the file why the response of one test is expected to differ from that of
another; there is too much separation between test setup, execution, and
assertions.

This commit reduces the amount of setup by changing only the adapter
through the use of tags and ExUnit's setup macro. This allows tests that
pivot on a particular adapter to define the adapter and declare it's use
right next to the tests that use it, bringing setup, execution, and
assertions closer together. This commit also brings common case tests to
the top of the file and groups non-common tests with describe blocks.