### PR TITLE
Add option to deliver_now to return adapter response

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -97,8 +97,8 @@ defmodule Bamboo.Mailer do
   `deliver_later/1` if you want to send in the background.
 
   Pass in an argument of `response: true` if you need access to the response
-  from delivering the email. This returns a tuple of the response from calling
-  `deliver` with your adapter and the `Email` struct. This is useful if you need
+  from delivering the email. This returns a tuple of the `Email` struct and the
+  response from calling `deliver` with your adapter. This is useful if you need
   access to any data sent back from your email provider in the response.
 
       Email.welcome_email |> Mailer.deliver_now(response: true)
@@ -130,7 +130,7 @@ defmodule Bamboo.Mailer do
     else
       debug_sent(email, adapter)
       response = adapter.deliver(email, config)
-      {response, email}
+      {email, response}
     end
   end
 

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -95,8 +95,15 @@ defmodule Bamboo.Mailer do
 
   Call your mailer with `deliver_now/1` to send an email right away. Call
   `deliver_later/1` if you want to send in the background.
+
+  Pass in an argument of `response: true` if you need access to the response
+  from delivering the email. This returns a tuple of the response from calling
+  `deliver` with your adapter and the `Email` struct. This is useful if you need
+  access to any data sent back from your email provider in the response.
+
+      Email.welcome_email |> Mailer.deliver_now(response: true)
   """
-  def deliver_now(_email) do
+  def deliver_now(_email, opts \\ []) do
     raise @cannot_call_directly_error
   end
 

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -63,7 +63,7 @@ defmodule Bamboo.Mailer do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      @spec deliver_now(Bamboo.Email.t()) :: Bamboo.Email.t()
+      @spec deliver_now(Bamboo.Email.t(), Enum.t()) :: Bamboo.Email.t() | {any, Bamboo.Email.t()}
       def deliver_now(email, opts \\ []) do
         config = build_config()
         Bamboo.Mailer.deliver_now(config.adapter, email, config, opts)
@@ -103,7 +103,7 @@ defmodule Bamboo.Mailer do
 
       Email.welcome_email |> Mailer.deliver_now(response: true)
   """
-  def deliver_now(_email, opts \\ []) do
+  def deliver_now(_email, _opts \\ []) do
     raise @cannot_call_directly_error
   end
 

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -265,13 +265,13 @@ defmodule Bamboo.MailerTest do
     end
 
     @tag adapter: ResponseAdapter
-    test "deliver_now/2 returns response and email when passing in response: true option" do
+    test "deliver_now/2 returns email and response when passing in response: true option" do
       email = new_email(to: "foo@bar.com")
 
-      {response, email} = Mailer.deliver_now(email, response: true)
+      {email, response} = Mailer.deliver_now(email, response: true)
 
-      assert %{body: _, headers: _, status_code: _} = response
       assert %Email{} = email
+      assert %{body: _, headers: _, status_code: _} = response
     end
 
     @tag adapter: ResponseAdapter

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -255,6 +255,35 @@ defmodule Bamboo.MailerTest do
     end
   end
 
+  describe "option to return response" do
+    defmodule ResponseAdapter do
+      def deliver(_email, _config) do
+        send(:mailer_test, %{status_code: 202, headers: [%{}], body: ""})
+      end
+
+      def handle_config(config), do: config
+    end
+
+    @tag adapter: ResponseAdapter
+    test "deliver_now/2 returns response and email when passing in response: true option" do
+      email = new_email(to: "foo@bar.com")
+
+      {response, email} = Mailer.deliver_now(email, response: true)
+
+      assert %{body: _, headers: _, status_code: _} = response
+      assert %Email{} = email
+    end
+
+    @tag adapter: ResponseAdapter
+    test "deliver_now/1 returns just email when not passing in response: true option" do
+      email = new_email(to: "foo@bar.com")
+
+      email = Mailer.deliver_now(email)
+
+      assert %Email{} = email
+    end
+  end
+
   defp new_email(attrs \\ []) do
     attrs = Keyword.merge([from: "foo@bar.com", to: "foo@bar.com"], attrs)
     Email.new_email(attrs)


### PR DESCRIPTION
As an alternative to #452, to resolve #451 and #161, this adds a `response: true` option to `deliver_now` that returns a tuple of the response from the adapter's `deliver` call and the `Email` struct. This is a non-breaking change, since without the `response: true` option everything will work as usual, and the `Email` will be returned, but this adds the option to pass that additional argument in and also get the response back.