### PR TITLE
Cleanup and clarify documentation

### DIFF
--- a/lib/bamboo/adapter.ex
+++ b/lib/bamboo/adapter.ex
@@ -2,13 +2,13 @@ defmodule Bamboo.Adapter do
   @moduledoc ~S"""
   Behaviour for creating Bamboo adapters
 
-  All recipients in the Bamboo.Email struct will be normalized to a 2 item tuple
-  of {name, address} when deliver through your mailer. For example,
-  `email.from |> elem(0)` would return the name and `email.from |> elem(1)`
-  would return the email address.
+  All recipients in the `Bamboo.Email` struct will be normalized to a two item
+  tuple of `{name, address}` when delivered through your mailer. For example,
+  `elem(email.from, 0)` would return the name and `elem(email.from, 1)` would
+  return the email address.
 
   For more in-depth examples check out the
-  [adapters in Bamboo](https://github.com/paulcsmith/bamboo/tree/master/lib/bamboo/adapters).
+  [adapters in Bamboo](https://github.com/thoughtbot/bamboo/tree/master/lib/bamboo/adapters).
 
   ## Example
 
@@ -27,11 +27,11 @@ defmodule Bamboo.Adapter do
           if Map.get(config, :smtp_username) do
             config
           else
-            raise "smtp_username is required in config, got #{inspect config}"
+            raise "smtp_username is required in config, got #{inspect(config)}"
           end
         end
-        
-        def supports_attachments?, do: true 
+
+        def supports_attachments?, do: true
       end
   """
 

--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -3,15 +3,15 @@ defmodule Bamboo.LocalAdapter do
   Stores emails locally. Can be queried to see sent emails.
 
   Use this adapter for storing emails locally instead of sending them. Emails
-  are stored and can be read from `Bamboo.SentEmail`.
-  Typically this adapter is used in the dev environment so emails are not
-  delivered to real email addresses.
+  are stored and can be read from `Bamboo.SentEmail`. Typically this adapter is
+  used in the dev environment so emails are not delivered to real email
+  addresses.
 
-  You can use this adapter along with `Bamboo.SentEmailViewerPlug` to view emails
-  in the browser.
+  You can use this adapter along with `Bamboo.SentEmailViewerPlug` to view
+  emails in the browser.
 
-  If you want to open a new browser window for every new email, set the
-  option `open_email_in_browser_url` to your preview path.
+  If you want to open a new browser window for every new email, set the option
+  `open_email_in_browser_url` to your preview path.
 
   ## Example config
 
@@ -30,13 +30,13 @@ defmodule Bamboo.LocalAdapter do
 
   @behaviour Bamboo.Adapter
 
-  @doc "Adds email to Bamboo.SentEmail and opens it in new browser tab"
+  @doc "Adds email to `Bamboo.SentEmail` and opens it in new browser tab"
   def deliver(email, %{open_email_in_browser_url: open_email_in_browser_url}) do
     %{private: %{local_adapter_id: local_adapter_id}} = SentEmail.push(email)
     open_url_in_browser("#{open_email_in_browser_url}/#{local_adapter_id}")
   end
 
-  @doc "Adds email to Bamboo.SentEmail"
+  @doc "Adds email to `Bamboo.SentEmail`"
   def deliver(email, _config) do
     SentEmail.push(email)
   end

--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -1,16 +1,17 @@
 defmodule Bamboo.MandrillHelper do
   @moduledoc """
-  Functions for using features specific to Mandrill e.g. tagging, merge vars, templates
+  Functions for using features specific to Mandrill (e.g. tagging, merge vars,
+  templates).
   """
 
   alias Bamboo.Email
 
   @doc """
-  Put extra message parameters that are used by Mandrill
+  Put extra message parameters that are used by Mandrill.
 
   Parameters set with this function are sent to Mandrill when used along with
-  the Bamboo.MandrillAdapter. You can set things like `important`, `merge_vars`,
-  and whatever else you need that the Mandrill API supports.
+  the `Bamboo.MandrillAdapter`. You can set things like `important`,
+  `merge_vars`, and whatever else you need that the Mandrill API supports.
 
   ## Example
 
@@ -37,7 +38,7 @@ defmodule Bamboo.MandrillHelper do
   end
 
   @doc """
-  Set merge_vars that are used by Mandrill
+  Set merge_vars that are used by Mandrill.
 
   ## Example
 

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -1,6 +1,6 @@
 defmodule Bamboo.TestAdapter do
   @moduledoc """
-  Used for testing email delivery
+  Used for testing email delivery.
 
   No emails are sent, instead a message is sent to the current process and can
   be asserted on with helpers from `Bamboo.Test`.

--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -2,18 +2,19 @@ defmodule Bamboo.Email do
   @moduledoc """
   Contains functions for composing emails.
 
-  Bamboo separates composing emails from delivering them. This separation makes emails
-  easy to test and makes things like using a default layout, or a default from
-  address easy to do. This module is for creating emails. To actually send them,
-  use [Bamboo.Mailer](Bamboo.Mailer.html).
+  Bamboo separates composing emails from delivering them. This separation makes
+  emails easy to test and makes things like using a default layout or a default
+  from address easy to do. This module is for creating emails. To actually send
+  them, use [Bamboo.Mailer](Bamboo.Mailer.html).
 
   ## Handling email addresses
 
-  The from, to, cc and bcc addresses accept a string, a 2 item tuple
-  {name, address}, or anything else that you create that implements the
-  [Bamboo.Formatter](Bamboo.Formatter.html) protocol. The to, cc and bcc fields
-  can also accepts a *list* of any combination of strings, 2 item tuples or
-  anything that implements the Bamboo.Formatter protocol. See
+  The from, to, cc, and bcc addresses of a `Bamboo.Email` can be set to any
+  data structure for which there is an implementation of the
+  [Bamboo.Formatter](Bamboo.Formatter.html) protocol or a list of such data
+  structures. Bamboo includes implementations for some common data structures
+  or you can create your own. All from, to, cc, and bcc addresses are
+  normalized internally to a two item tuple of `{name, address}`. See
   [Bamboo.Formatter](Bamboo.Formatter.html) for more info.
 
   ## Simplest way to create a new email
@@ -42,23 +43,30 @@ defmodule Bamboo.Email do
 
         def welcome_email(user) do
           # Since new_email/1 returns a struct you can update it with Kernel.struct!/2
-          struct!(base_email,
+          struct!(base_email(),
             to: user,
             subject: "Welcome!",
             text_body: "Welcome to the app",
             html_body: "<strong>Welcome to the app</strong>"
           )
-
-          # or you can use functions to build it up step by step
-          base_email
-          |> to(user)
-          |> subject("Welcome!")
-          |> text_body("Welcome to the app")
-          |> html_body("<strong>Welcome to the app</strong>")
         end
 
         def base_email do
           new_email(from: "me@app.com")
+        end
+      end
+
+  In addition to keyword lists, `Bamboo.Email`s can also be built using function pipelines.
+
+      defmodule MyApp.Email do
+        import Bamboo.Email
+
+        def welcome_email(user) do
+          base_email()
+          |> to(user)
+          |> subject("Welcome!")
+          |> text_body("Welcome to the app")
+          |> html_body("<strong>Welcome to the app</strong>")
         end
       end
   """
@@ -116,10 +124,10 @@ defmodule Bamboo.Email do
     @doc """
     Sets the `#{function_name}` on the email.
 
-    You can pass in a string, list of strings,
-    or anything that implements the `Bamboo.Formatter` protocol.
+    `#{function_name}` receives as an argument any data structure for which
+    there is an implementation of the [`Bamboo.Formatter`](Bamboo.Formatter.html) protocol.
 
-        new_email
+        new_email()
         |> #{function_name}(["sally@example.com", "james@example.com"])
     """
     @spec unquote(function_name)(__MODULE__.t(), address_list) :: __MODULE__.t()
@@ -209,7 +217,7 @@ defmodule Bamboo.Email do
 
       put_attachment(email, %Bamboo.Attachment{})
 
-  Requires the fields filename and data of the %Bamboo.Attachment{} struct to be set.
+  Requires the fields filename and data of the `%Bamboo.Attachment{}` struct to be set.
 
   ## Example
 

--- a/lib/bamboo/formatter.ex
+++ b/lib/bamboo/formatter.ex
@@ -2,10 +2,12 @@ defprotocol Bamboo.Formatter do
   @moduledoc ~S"""
   Converts data to email addresses.
 
-  The passed in options is currently a map with the key `:type` and a value of
-  `:from`, `:to`, `:cc` or `:bcc`. This makes it so that you can pattern match
-  and return a different address depending on if the address is being used in
-  the from, to, cc or bcc.
+  Implementations of the `Bamboo.Formatter` protocol convert a given data
+  structure to a two item tuple of `{name, address}` or an address string. The
+  `opts` argument is a map with the key `:type` and a value of `:from`, `:to`,
+  `:cc`, or `:bcc`. The options argument allows functions to pattern match an
+  address type and format a given data structure differently for different
+  types of addresses.
 
   ## Simple example
 
@@ -15,7 +17,7 @@ defprotocol Bamboo.Formatter do
         defstruct first_name: nil, last_name: nil, email: nil
       end
 
-  Bamboo can automatically format this struct if you implement the Bamboo.Formatter
+  Bamboo can automatically format this struct if you implement the `Bamboo.Formatter`
   protocol.
 
       defimpl Bamboo.Formatter, for: MyApp.User do
@@ -33,8 +35,10 @@ defprotocol Bamboo.Formatter do
 
   ## Customize formatting based on from, to, cc or bcc
 
-  This can be helpful if you want to add the name of the app when sending on
-  behalf of a user.
+  By pattern matching the `opts` argument, you can format a given data
+  structure differently for different types of addresses. For example, if you
+  want to provide the name of the app when sending email on behalf of a user,
+  you can format the name for all `type: :from` addresses.
 
       defimpl Bamboo.Formatter, for: MyApp.User do
         # Include the app name when used in a from address
@@ -52,7 +56,7 @@ defprotocol Bamboo.Formatter do
   """
 
   @doc ~S"""
-  Receives data and opts and should return a string or a 2 item tuple {name, address}
+  Receives data and opts and returns a string or a two item tuple `{name, address}`
 
   opts is a map with the key `:type` and a value of
   `:from`, `:to`, `:cc` or `:bcc`. You can pattern match on this to customize

--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -1,45 +1,78 @@
 defmodule Bamboo.Phoenix do
   @moduledoc """
-  Render templates and layouts with Phoenix.
+  Render emails with Phoenix templates and layouts.
 
-  This module makes it very easy to render layouts and views using Phoenix.
-  Pass an atom (e.g. `:welcome_email`) as the template name to render HTML and
+  This module allows rendering emails with Phoenix layouts and views. Pass an
+  atom (e.g. `:welcome_email`) as the template name to render both HTML and
   plain text emails. Use a string if you only want to render one type, e.g.
   `"welcome_email.text"` or `"welcome_email.html"`.
 
   ## Examples
 
-      defmodule Email do
+  _Set the text and HTML layout for an email._
+
+      defmodule MyApp.Email do
         use Bamboo.Phoenix, view: MyApp.EmailView
 
-        def text_and_html_email_with_layout do
+        def welcome_email do
           new_email()
-          # You could set just a text layout or just an html layout
           |> put_text_layout({MyApp.LayoutView, "email.text"})
           |> put_html_layout({MyApp.LayoutView, "email.html"})
-          # Or you can set a layout for both html and text at the same time
+          |> render(:welcome) # Pass atom to render html AND plain text templates
+        end
+      end
+
+  _Set both the text and HTML layout at the same time for an email._
+
+      defmodule MyApp.Email do
+        use Bamboo.Phoenix, view: MyApp.EmailView
+
+        def welcome_email do
+          new_email()
           |> put_layout({MyApp.LayoutView, :email})
-          # Pass an atom to render html AND plain text templates
-          |> render(:text_and_html_email)
+          |> render(:welcome)
         end
+      end
 
-        def text_and_html_email_without_layouts do
+  _Render both text and html emails without layouts._
+
+      defmodule MyApp.Email do
+        use Bamboo.Phoenix, view: MyApp.EmailView
+
+        def welcome_email do
           new_email()
-          |> render(:text_and_html_email)
+          |> render(:welcome)
         end
+      end
 
-        def email_with_assigns(user) do
-          new_email()
-          # @user will be available in the template
-          |> render(:email_with_assigns, user: user)
-        end
+  _Make assigns available to a template._
 
-        def email_with_already_assigned_user(user) do
+      defmodule MyApp.Email do
+        use Bamboo.Phoenix, view: MyApp.EmailView
+
+        def welcome_email(user) do
           new_email()
-          # @user will be available in the template
           |> assign(:user, user)
-          |> render(:email_with_assigns)
+          |> render(:welcome)
         end
+      end
+
+  _Make assigns available to a template during render call._
+
+      defmodule MyApp.Email do
+        use Bamboo.Phoenix, view: MyApp.EmailView
+
+        def welcome_email(user) do
+          new_email()
+          |> put_html_layout({MyApp.LayoutView, "email.html"})
+          |> render(:welcome, user: user)
+        end
+      end
+
+  _Render an email by passing the template string to render._
+
+      defmodule MyApp.Email do
+        use Bamboo.Phoenix, view: MyApp.EmailView
 
         def html_email do
           new_email
@@ -59,7 +92,7 @@ defmodule Bamboo.Phoenix do
         use Bamboo.Phoenix, view: Myapp.EmailView
 
         def sign_in_email(person) do
-          base_email
+          base_email()
           |> to(person)
           |> subject("Your Sign In Link")
           |> assign(:person, person)
@@ -110,7 +143,7 @@ defmodule Bamboo.Phoenix do
       @email_view_module unquote(view_module)
 
       @doc """
-      Render an Phoenix template and set the body on the email
+      Render an Phoenix template and set the body on the email.
 
       Pass an atom as the template name (:welcome_email) to render HTML *and* plain
       text emails. Use a string if you only want to render one type, e.g.
@@ -138,7 +171,7 @@ defmodule Bamboo.Phoenix do
   end
 
   @doc """
-  Render a Phoenix template and set the body on the email
+  Render a Phoenix template and set the body on the email.
 
   Pass an atom as the template name to render HTML *and* plain text emails,
   e.g. `:welcome_email`. Use a string if you only want to render one type, e.g.
@@ -149,7 +182,7 @@ defmodule Bamboo.Phoenix do
   end
 
   @doc """
-  Sets the layout when rendering HTML templates
+  Sets the layout when rendering HTML templates.
 
   ## Example
 
@@ -164,7 +197,7 @@ defmodule Bamboo.Phoenix do
   end
 
   @doc """
-  Sets the layout when rendering plain text templates
+  Sets the layout when rendering plain text templates.
 
   ## Example
 
@@ -179,7 +212,7 @@ defmodule Bamboo.Phoenix do
   end
 
   @doc """
-  Sets the layout for rendering plain text and HTML templates
+  Sets the layout for rendering plain text and HTML templates.
 
   ## Example
 

--- a/lib/bamboo/plug/sent_email_api/sent_email_api_plug.ex
+++ b/lib/bamboo/plug/sent_email_api/sent_email_api_plug.ex
@@ -3,12 +3,13 @@ defmodule Bamboo.SentEmailApiPlug do
   alias Bamboo.SentEmail
 
   @moduledoc """
-  A plug that can be used in your router to expose delivered emails over a
-  JSON API. This is useful for an integration test runner that doesn't have
+  A plug that exposes delivered emails over a JSON API.
+
+  This is useful for an integration test runner that doesn't have
   access to the `Bamboo.Test` helpers, but needs to be able to assert that
   emails have been delivered.
 
-  You must use the `Bamboo.LocalAdapter`, or no emails will be available.
+  You must use the `Bamboo.LocalAdapter` or no emails will be available.
 
   ## Using with Plug or Phoenix
 

--- a/lib/bamboo/sent_email.ex
+++ b/lib/bamboo/sent_email.ex
@@ -1,9 +1,9 @@
 defmodule Bamboo.SentEmail do
   @moduledoc """
-  Used for storing and retrieving sent emails when used with Bamboo.LocalAdapter
+  Used for storing and retrieving sent emails when used with `Bamboo.LocalAdapter`.
 
-  When emails are sent with the Bamboo.LocalAdapter, they are stored in
-  Bamboo.SentEmail. Use the functions in this module to store and retrieve the emails.
+  When emails are sent with the `Bamboo.LocalAdapter`, they are stored in
+  `Bamboo.SentEmail`. Use the functions in this module to store and retrieve the emails.
 
   Remember to start the Bamboo app by adding it to the app list in `mix.exs` or
   starting it with `Application.ensure_all_started(:bamboo)`
@@ -54,8 +54,8 @@ defmodule Bamboo.SentEmail do
   @doc """
   Gets the email's id.
 
-  The email must be an email that was sent with Bamboo.LocalAdapter or added
-  via SentEmail.push/1, otherwise the id will not have been set.
+  The email must be an email that was sent with `Bamboo.LocalAdapter` or added
+  via `Bamboo.SentEmail.push/1`, otherwise the id will not have been set.
   """
   def get_id(%Bamboo.Email{private: %{local_adapter_id: id}}) do
     id
@@ -100,10 +100,10 @@ defmodule Bamboo.SentEmail do
   end
 
   @doc """
-  Adds an email to the list of sent emails
+  Adds an email to the list of sent emails.
 
   Adds an email to the beginning of the sent emails list. Also gives the email
-  an id that can be fetched with SentEmail.get_id/1.
+  an id that can be fetched with `Bamboo.SentEmail.get_id/1`.
   """
   def push(email) do
     email = put_rand_id(email)

--- a/lib/bamboo/strategies/deliver_later_strategy.ex
+++ b/lib/bamboo/strategies/deliver_later_strategy.ex
@@ -1,10 +1,10 @@
 defmodule Bamboo.DeliverLaterStrategy do
   @moduledoc """
-  Behaviour for delivering emails with `Bamboo.Mailer.deliver_later/1`
+  Behaviour for delivering emails with `Bamboo.Mailer.deliver_later/1`.
 
-  Use this behaviour to create strategies for delivering later. You could make a
-  strategy using a GenServer, a background job library or whatever else you
-  decide.
+  Use this behaviour to create strategies for background email delivery. You
+  could make a strategy using a GenServer, a background job library or whatever
+  else you decide.
 
   ## Bamboo ships with two strategies:
 

--- a/lib/bamboo/strategies/immediate_delivery_strategy.ex
+++ b/lib/bamboo/strategies/immediate_delivery_strategy.ex
@@ -1,8 +1,10 @@
 defmodule Bamboo.ImmediateDeliveryStrategy do
   @moduledoc """
-  Strategy for deliver_later that sends the email immediately.
+  Strategy for `Bamboo.Mailer.deliver_later/1` that sends the email
+  immediately.
 
-  This strategy is used and required by the `Bamboo.LocalAdapter` and `Bamboo.TestAdapter`.
+  This strategy is used and required by the `Bamboo.LocalAdapter` and
+  `Bamboo.TestAdapter`.
   """
 
   @behaviour Bamboo.DeliverLaterStrategy

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -2,7 +2,7 @@ defmodule Bamboo.TaskSupervisorStrategy do
   @behaviour Bamboo.DeliverLaterStrategy
 
   @moduledoc """
-  Default strategy. Sends an email in the background using Task.Supervisor
+  Default strategy. Sends an email in the background using `Task.Supervisor`.
 
   This is the default strategy when calling `deliver_later` because it is the
   simplest to get started with. This strategy uses a `Task.Supervisor` to monitor

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -2,10 +2,10 @@ defmodule Bamboo.Test do
   import ExUnit.Assertions
 
   @moduledoc """
-  Helpers for testing email delivery
+  Helpers for testing email delivery.
 
-  Use these helpers with Bamboo.TestAdapter to test email delivery. Typically
-  you'll want to **unit test emails first**. Then in integration tests use
+  Use these helpers with `Bamboo.TestAdapter` to test email delivery. Typically
+  you'll want to **unit test emails first**. Then, in integration tests, use
   helpers from this module to test whether that email was delivered.
 
   ## Note on sending from other processes
@@ -73,7 +73,7 @@ defmodule Bamboo.Test do
   """
 
   @doc """
-  Imports Bamboo.Test and Bamboo.Formatter.format_email_address/2
+  Imports `Bamboo.Test` and `Bamboo.Formatter.format_email_address/2`
 
   `Bamboo.Test` and the `Bamboo.TestAdapter` work by sending a message to the
   current process when an email is delivered. The process mailbox is then


### PR DESCRIPTION
While reading through Bamboo's source code, there were a few places in
the documentation I found that could be clearer or had minor typos. This
commit aims to clarify some of the documentation and fix minor typos
here and there.