### PR TITLE
WIP: Allow multiple header values for the same key

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,43 @@ struct directly to Bamboo anywhere it expects an address. See the
 [`Bamboo.Email`] and [`Bamboo.Formatter`] docs for more information and
 examples.
 
+## Handling Headers
+
+When constructing emails, headers exist as a map where the map key represents
+the header's key and the map value may be either a string or a list of strings.
+
+There are two main ways to add headers to an email:
+
+1. By passing a `headers` key to `Email.new_email/1`
+
+```elixir
+Email.new_email(%{headers: "key" => "value"})
+```
+
+2. By using `Email.put_header/4`
+
+```elixir
+%{}
+|> Email.new_email()
+|> Email.put_header("key", "value")
+```
+
+When adding headers via `Email.put_header/4` two strategies exist for adding
+headers of the same key. First, and by default, calling `Email.put_header/4`
+with a header key that already exists in the headers map will replace the
+existing value with the new argument. Second, a list of values can be produced
+by calling `Email.put_header/4` with `:combine` as the fourth argument multiple
+times with the same header key and different values. This makes the header
+value for that key a list of values.
+
+When the email is sent, headers should be normalized by calling
+`Mailer.normalize_headers/2`. This transforms the headers map into a list of
+two element tuples. Headers with list values can be transformed into a single
+comma separated string by passing `:csv` as the second argument (the default
+option) or into a list of two element tuples where the first element is the
+repeated key and the second element one of its values by passing `:list` as the
+second argument.
+
 ## Using Phoenix Views and Layouts
 
 Phoenix is not required to use Bamboo. However, if you do use Phoenix, you can

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -1,59 +1,9 @@
 defmodule Bamboo.EmailTest do
   use ExUnit.Case
-
   import Bamboo.Email
+  alias Bamboo.Email
 
-  test "new_email/1 returns an Email struct" do
-    assert new_email() == %Bamboo.Email{
-             from: nil,
-             to: nil,
-             cc: nil,
-             bcc: nil,
-             subject: nil,
-             html_body: nil,
-             text_body: nil,
-             headers: %{}
-           }
-  end
-
-  test "new_email/1 can override email attributes with lists or maps" do
-    email_attrs = %{to: "foo@bar.com", subject: "Cool Email"}
-    email = new_email(email_attrs)
-    assert email.to == "foo@bar.com"
-    assert email.subject == "Cool Email"
-
-    email_attrs = [to: "foo@bar.com", subject: "Cool Email"]
-    email = new_email(email_attrs)
-    assert email.to == "foo@bar.com"
-    assert email.subject == "Cool Email"
-  end
-
-  test "get_address gets the address or raises if not normalized" do
-    assert get_address({"Paul", "paul@gmail.com"}) == "paul@gmail.com"
-
-    assert_raise RuntimeError, ~r/expected an address/, fn ->
-      get_address({})
-    end
-  end
-
-  test "returns list of all recipients" do
-    email =
-      new_email(from: "foo", to: "to@foo.com", cc: "cc@foo.com", bcc: "bcc@foo.com")
-      |> Bamboo.Mailer.normalize_addresses()
-
-    assert all_recipients(email) == [
-             {nil, "to@foo.com"},
-             {nil, "cc@foo.com"},
-             {nil, "bcc@foo.com"}
-           ]
-  end
-
-  test "raises if emails are not normalized" do
-    assert_raise RuntimeError, ~r/normalized/, fn ->
-      email = new_email(to: ["to@foo.com"])
-      all_recipients(email)
-    end
-  end
+  doctest Bamboo.Email
 
   test "can pipe updates with functions" do
     email =
@@ -73,10 +23,176 @@ defmodule Bamboo.EmailTest do
     assert email.headers["Reply-To"] == "reply@foo.com"
   end
 
-  test "put_private/3 puts a key and value in the private attribute" do
-    email = new_email() |> put_private("foo", "bar")
+  describe "new_email/1" do
+    test "returns an Email struct" do
+      assert new_email() == %Email{
+               from: nil,
+               to: nil,
+               cc: nil,
+               bcc: nil,
+               subject: nil,
+               html_body: nil,
+               text_body: nil,
+               headers: %{}
+             }
+    end
 
-    assert email.private["foo"] == "bar"
+    test "can override email attributes with a map" do
+      email_attrs = %{to: "foo@bar.com", subject: "Cool Email"}
+      email = new_email(email_attrs)
+
+      assert email.to == "foo@bar.com"
+      assert email.subject == "Cool Email"
+    end
+
+    test "can override email attributes with a list" do
+      email_attrs = [to: "foo@bar.com", subject: "Cool Email"]
+      email = new_email(email_attrs)
+
+      assert email.to == "foo@bar.com"
+      assert email.subject == "Cool Email"
+    end
+  end
+
+  describe "get_address/1" do
+    test "gets the address of a normalized address" do
+      assert get_address({"Paul", "paul@gmail.com"}) == "paul@gmail.com"
+    end
+
+    test "raises an error for a non-normalized address" do
+      assert_raise RuntimeError, ~r/expected an address/, fn -> get_address({}) end
+    end
+  end
+
+  describe "all_recipients/1" do
+    test "returns list of all recipients" do
+      email =
+        new_email(from: "foo", to: "to@foo.com", cc: "cc@foo.com", bcc: "bcc@foo.com")
+        |> Bamboo.Mailer.normalize_addresses()
+
+      assert all_recipients(email) == [
+               {nil, "to@foo.com"},
+               {nil, "cc@foo.com"},
+               {nil, "bcc@foo.com"}
+             ]
+    end
+
+    test "raises if emails are not normalized" do
+      assert_raise RuntimeError, ~r/normalized/, fn ->
+        email = new_email(to: ["to@foo.com"])
+        all_recipients(email)
+      end
+    end
+  end
+
+  describe "put_header/3" do
+    test "adds a field value for a new field name" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", "mario")
+
+      assert email.headers == %{"x-hero" => "mario"}
+    end
+
+    test "replaces the value for an existing field name" do
+      email =
+        %{headers: %{"x-hero" => "mario"}}
+        |> new_email()
+        |> Email.put_header("x-hero", "luigi")
+
+      assert email.headers == %{"x-hero" => "luigi"}
+    end
+
+    test "accepts a list as a value" do
+      email =
+        new_email()
+        |> Email.put_header("x-hero", ["mario", "luigi"])
+
+      assert email.headers == %{"x-hero" => ["mario", "luigi"]}
+    end
+
+    test "does not change headers for a non-string value" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", %{name: "mario"})
+
+      assert email.headers == %{}
+    end
+
+    test "does not change headers for a nil value" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", nil)
+
+      assert email.headers == %{}
+    end
+  end
+
+  describe "put_header/3 :combine" do
+    test "adds a field value for a new field name" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", "mario", :combine)
+
+      assert email.headers == %{"x-hero" => "mario"}
+    end
+
+    test "makes the value a list for an existing field name" do
+      email =
+        %{headers: %{"x-hero" => "mario"}}
+        |> new_email()
+        |> Email.put_header("x-hero", "luigi", :combine)
+
+      assert email.headers == %{"x-hero" => ["luigi", "mario"]}
+    end
+
+    test "adds to a list of field values for an existing field name" do
+      email =
+        %{headers: %{"x-hero" => ["mario", "luigi"]}}
+        |> new_email()
+        |> Email.put_header("x-hero", "dk", :combine)
+
+      assert email.headers == %{"x-hero" => ["dk", "mario", "luigi"]}
+    end
+
+    test "adds a new list to the list of field values for an existing field name" do
+      email =
+        %{headers: %{"x-hero" => ["mario", "luigi"]}}
+        |> new_email()
+        |> Email.put_header("x-hero", ["dk", "yoshi"], :combine)
+
+      assert email.headers == %{"x-hero" => ["dk", "yoshi", "mario", "luigi"]}
+    end
+
+    test "does not change headers for a non-string value" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", %{name: "mario"}, :combine)
+
+      assert email.headers == %{}
+    end
+
+    test "does not change headers for a nil value" do
+      email =
+        %{headers: %{}}
+        |> new_email()
+        |> Email.put_header("x-hero", nil, :combine)
+
+      assert email.headers == %{}
+    end
+  end
+
+  describe "put_private/3" do
+    test "put_private/3 puts a key and value in the private attribute" do
+      email = new_email() |> put_private("foo", "bar")
+
+      assert email.private["foo"] == "bar"
+    end
   end
 
   describe "put_attachment/2" do
@@ -110,10 +226,12 @@ defmodule Bamboo.EmailTest do
     end
   end
 
-  test "put_attachment/3 adds an attachment to the attachments list" do
-    path = Path.join(__DIR__, "../../support/attachment.docx")
-    email = new_email() |> put_attachment(path)
+  describe "put_attachment/3" do
+    test " adds an attachment to the attachments list" do
+      path = Path.join(__DIR__, "../../support/attachment.docx")
+      email = new_email() |> put_attachment(path)
 
-    assert [%Bamboo.Attachment{filename: "attachment.docx"}] = email.attachments
+      assert [%Bamboo.Attachment{filename: "attachment.docx"}] = email.attachments
+    end
   end
 end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -288,4 +288,45 @@ defmodule Bamboo.MailerTest do
     attrs = Keyword.merge([from: "foo@bar.com", to: "foo@bar.com"], attrs)
     Email.new_email(attrs)
   end
+
+  describe "normalize_headers/2 :list" do
+    test "transforms a single value to a tuple" do
+      email = new_email(headers: %{"Hero" => "mario", "villain" => "bowser"})
+
+      headers = Bamboo.Mailer.normalize_headers(email, :list)
+
+      assert {"Hero", "mario"} in headers
+      assert {"villain", "bowser"} in headers
+    end
+
+    test "transforms a list of values to a list of tuples" do
+      email = new_email(headers: %{"Hero" => ["luigi", "mario"], "villain" => "bowser"})
+
+      headers = Bamboo.Mailer.normalize_headers(email, :list)
+
+      assert {"Hero", "mario"} in headers
+      assert {"Hero", "luigi"} in headers
+      assert {"villain", "bowser"} in headers
+    end
+  end
+
+  describe "normalize_headers/2 :csv" do
+    test "transforms a single value to a tuple" do
+      email = new_email(headers: %{"Hero" => "mario", "villain" => "bowser"})
+
+      headers = Bamboo.Mailer.normalize_headers(email, :csv)
+
+      assert {"Hero", "mario"} in headers
+      assert {"villain", "bowser"} in headers
+    end
+
+    test "transforms a list of values to a comma separated string" do
+      email = new_email(headers: %{"Hero" => ["luigi", "mario"], "villain" => "bowser"})
+
+      headers = Bamboo.Mailer.normalize_headers(email, :csv)
+
+      assert {"Hero", "mario, luigi"} in headers
+      assert {"villain", "bowser"} in headers
+    end
+  end
 end


### PR DESCRIPTION
The Email struct can have multiple values added for the same name. This
commit updates the `put_header` function on the Email module by allowing
header values to be added as a list and combining multiple values for
the same name into lists. The Mailer module also has a function to
normalize those headers into a list of two element tuples to can be sent
to the http client library based on the strategy elected by the caller.

Resolves #469, #343, #360