### PR TITLE
Adding content_id for displaying attachements in HTML email

### DIFF
--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -8,7 +8,8 @@ defmodule Bamboo.Attachment do
           path: nil | String.t(),
           filename: nil | String.t(),
           content_type: nil | String.t(),
-          data: nil | binary()
+          data: nil | binary(),
+          content_id: nil | String.t()
         }
 
   @doc ~S"""
@@ -44,7 +45,14 @@ defmodule Bamboo.Attachment do
     content_type = opts[:content_type] || determine_content_type(path)
     content_id = opts[:content_id]
     data = File.read!(path)
-    %__MODULE__{path: path, data: data, filename: filename, content_type: content_type, content_id: content_id}
+
+    %__MODULE__{
+      path: path,
+      data: data,
+      filename: filename,
+      content_type: content_type,
+      content_id: content_id
+    }
   end
 
   defp determine_content_type(path) do

--- a/lib/bamboo/attachment.ex
+++ b/lib/bamboo/attachment.ex
@@ -2,7 +2,7 @@ defmodule Bamboo.Attachment do
   @moduledoc """
   """
 
-  defstruct filename: nil, content_type: nil, path: nil, data: nil
+  defstruct filename: nil, content_type: nil, path: nil, data: nil, content_id: nil
 
   @type t :: %__MODULE__{
           path: nil | String.t(),
@@ -14,12 +14,23 @@ defmodule Bamboo.Attachment do
   @doc ~S"""
   Creates a new Attachment
 
+  context_id can be use to embed an image, attach it and reference in the message body by
+  setting its CID (Content-ID) and using a standard HTML tag:
+
+    <img src="cid:some-image-cid" alt="img" />
+
+  within a HTML email message.
+
   Examples:
 
       Bamboo.Attachment.new("/path/to/attachment.png")
       Bamboo.Attachment.new("/path/to/attachment.png", filename: "image.png")
-      Bamboo.Attachment.new("/path/to/attachment.png", filename: "image.png", content_type: "image/png")
+      Bamboo.Attachment.new("/path/to/attachment.png", filename: "image.png", content_type: "image/png", content_id: "12387432")
       Bamboo.Attachment.new(params["file"]) # Where params["file"] is a %Plug.Upload
+
+      email
+        |> put_html_layout({LayoutView, "email.html"})
+        |> put_attachment(%Bamboo.Attachment{content_type: "image/png", filename: "logo.png", data: get_content(), content_id: "2343333333"})
   """
   def new(path, opts \\ [])
 
@@ -31,8 +42,9 @@ defmodule Bamboo.Attachment do
   def new(path, opts) do
     filename = opts[:filename] || Path.basename(path)
     content_type = opts[:content_type] || determine_content_type(path)
+    content_id = opts[:content_id]
     data = File.read!(path)
-    %__MODULE__{path: path, data: data, filename: filename, content_type: content_type}
+    %__MODULE__{path: path, data: data, filename: filename, content_type: content_type, content_id: content_id}
   end
 
   defp determine_content_type(path) do

--- a/test/lib/bamboo/attachments_test.exs
+++ b/test/lib/bamboo/attachments_test.exs
@@ -32,6 +32,12 @@ defmodule Bamboo.AttachmentTest do
     assert attachment.content_type == "application/msword"
   end
 
+  test "create an attachment with a specified content id" do
+    path = Path.join(__DIR__, "../../support/attachment.docx")
+    attachment = Attachment.new(path, content_id: "DocAttachment1234")
+    assert attachment.content_id == "DocAttachment1234"
+  end
+
   test "create an attachment from a Plug Upload struct" do
     path = Path.join(__DIR__, "../../support/attachment.docx")
     upload = %Plug.Upload{filename: "test.docx", content_type: "application/msword", path: path}

--- a/test/lib/bamboo/email_test.exs
+++ b/test/lib/bamboo/email_test.exs
@@ -91,7 +91,7 @@ defmodule Bamboo.EmailTest do
       attachment = %Bamboo.Attachment{filename: nil, data: "content"}
 
       msg =
-        "You must provide a filename for the attachment, instead got: %Bamboo.Attachment{content_type: nil, data: \"content\", filename: nil, path: nil}"
+        "You must provide a filename for the attachment, instead got: %Bamboo.Attachment{content_id: nil, content_type: nil, data: \"content\", filename: nil, path: nil}"
 
       assert_raise RuntimeError, msg, fn ->
         new_email() |> put_attachment(attachment)
@@ -102,7 +102,7 @@ defmodule Bamboo.EmailTest do
       attachment = %Bamboo.Attachment{filename: "attachment.docx", data: nil}
 
       msg =
-        "The attachment must contain data, instead got: %Bamboo.Attachment{content_type: nil, data: nil, filename: \"attachment.docx\", path: nil}"
+        "The attachment must contain data, instead got: %Bamboo.Attachment{content_id: nil, content_type: nil, data: nil, filename: \"attachment.docx\", path: nil}"
 
       assert_raise RuntimeError, msg, fn ->
         new_email() |> put_attachment(attachment)


### PR DESCRIPTION
Adding content_id for displaying attachements in HTML email. The corresponding changes to bamboo_smtp have been made and a PR created for it.