### PR TITLE
Support Mailgun EU region

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ adapter itself.
 # config/config.exs
 config :my_app, MyApp.Mailer,
   adapter: Bamboo.MandrillAdapter,
-  api_key: "my_api_key"
+  api_key: "my_api_key",
+  region: "eu" # not required for US
 ```
 
 _Other adapter-specific configuration may be required. Be sure to check the

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -11,7 +11,8 @@ defmodule Bamboo.MailgunAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.MailgunAdapter,
         api_key: "my_api_key" # or {:system, "MAILGUN_API_KEY"},
-        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"}
+        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"},
+        region: "eu" # or {:system, "MAILGUN_DOMAIN"}, (leave blank for US)
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
@@ -20,7 +21,6 @@ defmodule Bamboo.MailgunAdapter do
   """
 
   @service_name "Mailgun"
-  @base_uri "https://api.mailgun.net/v3"
   @behaviour Bamboo.Adapter
 
   alias Bamboo.{Email, Attachment}
@@ -81,7 +81,14 @@ defmodule Bamboo.MailgunAdapter do
   def supports_attachments?, do: true
 
   defp full_uri(config) do
-    Application.get_env(:bamboo, :mailgun_base_uri, @base_uri) <>
+    uri =
+      if Map.has_key?(config, :region) do
+        "https://api.#{config.region}.mailgun.net/v3"
+      else
+        "https://api.mailgun.net/v3"
+      end
+
+    Application.get_env(:bamboo, :mailgun_base_uri, uri) <>
       "/" <> config.domain <> "/messages"
   end
 


### PR DESCRIPTION
Mailgun now has two regions: US (default) and EU. Much due to GDPR regulations. https://www.mailgun.com/regions

I'm open for further suggestions.