### PR TITLE
Add an adapter for Campaign Monitor

### DIFF
--- a/lib/bamboo/adapters/campaign_monitor_adapter.ex
+++ b/lib/bamboo/adapters/campaign_monitor_adapter.ex
@@ -1,0 +1,194 @@
+defmodule Bamboo.CampaignMonitorAdapter do
+  @moduledoc """
+  Sends email using Campaign Monitor's JSON API.
+
+  Use this adapter to send emails through Campaign Monitor's API. Requires that an API
+  key is set in the config.
+
+  If you would like to add a replyto header to your email, then simply pass it in
+  using the header property or put_header function like so:
+
+      put_header("reply-to", "foo@bar.com")
+
+  ## Example config
+
+      # In config/config.exs, or config.prod.exs, etc.
+      config :my_app, MyApp.Mailer,
+        adapter: Bamboo.CampaignMonitorAdapter,
+        api_key: "my_api_key", # or System.get_env("API_KEY") 
+        client_id: "my_client_id" # or System.get_env("CLIENT_ID")
+      # Define a Mailer. Maybe in lib/my_app/mailer.ex
+      defmodule MyApp.Mailer do
+        use Bamboo.Mailer, otp_app: :my_app
+      end
+  """
+
+  @service_name "CampaignMonitor"
+  @default_base_uri "https://api.createsend.com/api/v3.2"
+  @classic_email_path "/transactional/classicEmail/send"
+  @smart_email_path "/transactional/smartEmail/[smartEmailId]/send"
+  @behaviour Bamboo.Adapter
+
+  alias Bamboo.Email
+  import Bamboo.ApiError
+
+  def deliver(email, config) do
+    api_key = get_from_config(config, :api_key)
+    body = email |> to_campaign_monitor_body(config) |> Jason.encode!()
+    url = [base_uri(), get_path(email, config)]
+
+    case :hackney.post(url, headers(api_key), body, [:with_body]) do
+      {:ok, status, _headers, response} when status > 299 ->
+        filtered_params = body |> Jason.decode!() |> Map.put("key", "[FILTERED]")
+        raise_api_error(@service_name, response, filtered_params)
+
+      {:ok, status, headers, response} ->
+        %{status_code: status, headers: headers, body: response}
+
+      {:error, reason} ->
+        raise_api_error(inspect(reason))
+    end
+  end
+
+  @doc false
+  def handle_config(config) do
+    # build the api key - will raise if there are errors
+    Map.merge(config, %{api_key: get_from_config(config, :api_key)})
+  end
+
+  @doc false
+  def supports_attachments?, do: false
+
+  defp get_from_config(config, key) do
+    value =
+      case Map.get(config, key) do
+        {:system, var} -> System.get_env(var)
+        key -> key
+      end
+
+    if value in [nil, ""] do
+      raise_api_key_error(config)
+    else
+      value
+    end
+  end
+
+  defp raise_api_key_error(config) do
+    raise ArgumentError, """
+    There was no API key set for the Campaign Monitor adapter.
+
+    * Here are the config options that were passed in:
+
+    #{inspect(config)}
+    """
+  end
+
+  defp headers(api_key) do
+    [
+      {"Content-Type", "application/json"},
+      {"Accept", "application/json"},
+      {"Authorization", "Basic #{Base.encode64(api_key <> ":x")}"}
+    ]
+  end
+
+  # get the path based on the type of email (smart/classic)
+  defp get_path(%Email{private: %{smart_email_id: smart_email_id}}, _) do
+    String.replace(@smart_email_path, "[smartEmailId]", smart_email_id)
+  end
+
+  defp get_path(%Email{}, config) do
+    client_id = get_from_config(config, :client_id)
+    @classic_email_path <> "?clientID=#{client_id}"
+  end
+
+  defp to_campaign_monitor_body(email = %Email{}, _config) do
+    %{}
+    |> put_to(email)
+    |> put_cc(email)
+    |> put_bcc(email)
+    |> put_from(email)
+    |> put_reply_to(email)
+    |> put_subject(email)
+    |> put_html_body(email)
+    |> put_text_body(email)
+    |> put_consent_to_track(email)
+    |> put_tracking_group(email)
+    |> put_smart_email_data(email)
+  end
+
+  defp put_from(body, %Email{from: from}) do
+    Map.put(body, "From", to_address(from))
+  end
+
+  defp put_to(body, %Email{to: to}) do
+    put_addresses(body, "To", to)
+  end
+
+  defp put_cc(body, %Email{cc: []}), do: body
+
+  defp put_cc(body, %Email{cc: cc}) do
+    put_addresses(body, "CC", cc)
+  end
+
+  defp put_bcc(body, %Email{bcc: []}), do: body
+
+  defp put_bcc(body, %Email{bcc: bcc}) do
+    put_addresses(body, "BCC", bcc)
+  end
+
+  defp put_reply_to(body, %Email{headers: %{"reply-to" => reply_to}}) do
+    Map.put(body, "ReplyTo", reply_to)
+  end
+
+  defp put_reply_to(body, _), do: body
+
+  defp put_subject(body, %Email{subject: subject}) when not is_nil(subject),
+    do: Map.put(body, "Subject", subject)
+
+  defp put_subject(body, _), do: body
+
+  defp put_html_body(body, %Email{html_body: nil}), do: body
+
+  defp put_html_body(body, %Email{html_body: html_body}) do
+    Map.put(body, "Html", html_body)
+  end
+
+  defp put_text_body(body, %Email{text_body: nil}), do: body
+
+  defp put_text_body(body, %Email{text_body: text_body}) do
+    Map.put(body, "Text", text_body)
+  end
+
+  defp put_consent_to_track(body, %Email{private: %{consent_to_track: "Yes"}}) do
+    Map.put(body, "ConsentToTrack", "Yes")
+  end
+
+  defp put_consent_to_track(body, _) do
+    Map.put(body, "ConsentToTrack", "No")
+  end
+
+  defp put_tracking_group(body, %Email{private: %{group: group}}) do
+    Map.put(body, "Group", group)
+  end
+
+  defp put_tracking_group(body, _), do: body
+
+  defp put_smart_email_data(body, %Email{private: %{smart_email_data: data}}) do
+    Map.put(body, "Data", data)
+  end
+
+  defp put_smart_email_data(body, _), do: body
+
+  defp put_addresses(body, _, []), do: body
+
+  defp put_addresses(body, field, addresses),
+    do: Map.put(body, field, Enum.map(addresses, &to_address/1))
+
+  defp to_address({nil, address}), do: address
+  defp to_address({"", address}), do: address
+  defp to_address({name, address}), do: "#{name} <#{address}>"
+
+  defp base_uri do 
+    Application.get_env(:bamboo, :campaign_monitor_base_uri) || @default_base_uri
+  end
+end

--- a/lib/bamboo/adapters/campaign_monitor_adapter.ex
+++ b/lib/bamboo/adapters/campaign_monitor_adapter.ex
@@ -188,7 +188,7 @@ defmodule Bamboo.CampaignMonitorAdapter do
   defp to_address({"", address}), do: address
   defp to_address({name, address}), do: "#{name} <#{address}>"
 
-  defp base_uri do 
+  defp base_uri do
     Application.get_env(:bamboo, :campaign_monitor_base_uri) || @default_base_uri
   end
 end

--- a/test/lib/bamboo/adapters/camapign_monitor_adapter_test.exs
+++ b/test/lib/bamboo/adapters/camapign_monitor_adapter_test.exs
@@ -1,0 +1,181 @@
+defmodule Bamboo.CampaignMonitorAdapterTest do
+  use ExUnit.Case
+  alias Bamboo.Email
+  alias Bamboo.CampaignMonitorAdapter
+
+  @config %{adapter: CampaignMonitorAdapter, api_key: "123_abc", client_id: "client_123"}
+  @config_with_bad_key %{adapter: CampaignMonitorAdapter, api_key: nil, client_id: nil}
+  @config_with_env_var_key %{adapter: CampaignMonitorAdapter, api_key: {:system, "CAMPAIGN_MONITOR_API_KEY"}, client_id: {:system, "CAMPAIGN_MONITOR_CLIENT_ID"}}
+
+  defmodule FakeCampaignMonitor do
+    use Plug.Router
+
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    )
+
+    plug(:match)
+    plug(:dispatch)
+
+    def start_server(parent) do
+      Agent.start_link(fn -> Map.new() end, name: __MODULE__)
+      Agent.update(__MODULE__, &Map.put(&1, :parent, parent))
+      port = get_free_port()
+      Application.put_env(:bamboo, :campaign_monitor_base_uri, "http://localhost:#{port}")
+      Plug.Adapters.Cowboy.http(__MODULE__, [], port: port, ref: __MODULE__)
+    end
+
+    defp get_free_port do
+      {:ok, socket} = :ranch_tcp.listen(port: 0)
+      {:ok, port} = :inet.port(socket)
+      :erlang.port_close(socket)
+      port
+    end
+
+    def shutdown do
+      Plug.Adapters.Cowboy.shutdown(__MODULE__)
+    end
+
+    post "/transactional/classicEmail/send" do
+      case get_in(conn.params, ["From"]) do
+        "INVALID_EMAIL" -> conn |> send_resp(500, "Error!!") |> send_to_parent
+        _ -> conn |> send_resp(200, "SENT") |> send_to_parent
+      end
+    end
+
+    defp send_to_parent(conn) do
+      parent = Agent.get(__MODULE__, fn set -> Map.get(set, :parent) end)
+      send(parent, {:fake_campaign_monitor, conn})
+      conn
+    end
+  end
+
+  setup do
+    FakeCampaignMonitor.start_server(self())
+
+    on_exit(fn ->
+      FakeCampaignMonitor.shutdown()
+    end)
+
+    :ok
+  end
+
+  test "raises if the api key is nil" do
+    assert_raise ArgumentError, ~r/no API key set/, fn ->
+      new_email(from: "foo@bar.com") |> CampaignMonitorAdapter.deliver(@config_with_bad_key)
+    end
+
+    assert_raise ArgumentError, ~r/no API key set/, fn ->
+      CampaignMonitorAdapter.handle_config(%{})
+    end
+  end
+
+  test "can read the api key from an ENV var" do
+    System.put_env("CAMPAIGN_MONITOR_API_KEY", "123_abc")
+
+    config = CampaignMonitorAdapter.handle_config(@config_with_env_var_key)
+
+    assert config[:api_key] == "123_abc"
+  end
+
+  test "raises if an invalid ENV var is used for the API key" do
+    System.delete_env("CAMPAIGN_MONITOR_API_KEY")
+
+    assert_raise ArgumentError, ~r/no API key set/, fn ->
+      new_email(from: "foo@bar.com") |> CampaignMonitorAdapter.deliver(@config_with_env_var_key)
+    end
+
+    assert_raise ArgumentError, ~r/no API key set/, fn ->
+      CampaignMonitorAdapter.handle_config(@config_with_env_var_key)
+    end
+  end
+
+  test "deliver/2 sends the to the right url" do
+    new_email() |> CampaignMonitorAdapter.deliver(@config)
+
+    assert_receive {:fake_campaign_monitor, %{request_path: request_path}}
+
+    assert request_path == "/transactional/classicEmail/send"
+  end
+
+  test "deliver/2 sends from, html and text body, subject" do
+    email =
+      new_email(
+        from: {"From", "from@foo.com"},
+        subject: "My Subject",
+        text_body: "TEXT BODY",
+        html_body: "HTML BODY"
+      )
+      |> Email.put_header("Reply-To", "reply@foo.com")
+
+    email |> CampaignMonitorAdapter.deliver(@config)
+
+    refute CampaignMonitorAdapter.supports_attachments?()
+    assert_receive {:fake_campaign_monitor, %{params: params, req_headers: headers}}
+
+    assert params["From"] == "From <from@foo.com>"
+    assert params["Subject"] == email.subject
+    assert params["Text"] == email.text_body
+    assert params["Html"] == email.html_body
+  end
+
+  test "deliver/2 correctly formats recipients" do
+    email =
+      new_email(
+        to: [{"To", "to@bar.com"}, {nil, "noname@bar.com"}],
+        cc: [{"CC", "cc@bar.com"}],
+        bcc: [{"BCC", "bcc@bar.com"}]
+      )
+
+    email |> CampaignMonitorAdapter.deliver(@config)
+
+    assert_receive {:fake_campaign_monitor, %{params: params}}
+    
+    assert params["To"] == ["To <to@bar.com>", "noname@bar.com"]
+    assert params["BCC"] == ["BCC <bcc@bar.com>"]
+    assert params["CC"] == ["CC <cc@bar.com>"]
+  end
+
+  test "deliver/2 doesn't force a subject" do
+    email = new_email(from: {"From", "from@foo.com"})
+
+    email
+    |> CampaignMonitorAdapter.deliver(@config)
+
+    assert_receive {:fake_campaign_monitor, %{params: params}}
+    refute Map.has_key?(params, "subject")
+  end
+
+  test "deliver/2 correctly formats reply-to from headers" do
+    email = new_email(headers: %{"reply-to" => "foo@bar.com"})
+
+    email |> CampaignMonitorAdapter.deliver(@config)
+
+    assert_receive {:fake_campaign_monitor, %{params: params}}
+    assert params["ReplyTo"] == "foo@bar.com" 
+  end
+
+  test "raises if the response is not a success" do
+    email = new_email(from: "INVALID_EMAIL")
+
+    assert_raise Bamboo.ApiError, fn ->
+      email |> CampaignMonitorAdapter.deliver(@config)
+    end
+  end
+
+  test "removes api key from error output" do
+    email = new_email(from: "INVALID_EMAIL")
+
+    assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
+      email |> CampaignMonitorAdapter.deliver(@config)
+    end
+  end
+
+  defp new_email(attrs \\ []) do
+    attrs = Keyword.merge([from: "foo@bar.com", to: []], attrs)
+    Email.new_email(attrs) |> Bamboo.Mailer.normalize_addresses()
+  end
+end

--- a/test/lib/bamboo/adapters/camapign_monitor_adapter_test.exs
+++ b/test/lib/bamboo/adapters/camapign_monitor_adapter_test.exs
@@ -5,7 +5,11 @@ defmodule Bamboo.CampaignMonitorAdapterTest do
 
   @config %{adapter: CampaignMonitorAdapter, api_key: "123_abc", client_id: "client_123"}
   @config_with_bad_key %{adapter: CampaignMonitorAdapter, api_key: nil, client_id: nil}
-  @config_with_env_var_key %{adapter: CampaignMonitorAdapter, api_key: {:system, "CAMPAIGN_MONITOR_API_KEY"}, client_id: {:system, "CAMPAIGN_MONITOR_CLIENT_ID"}}
+  @config_with_env_var_key %{
+    adapter: CampaignMonitorAdapter,
+    api_key: {:system, "CAMPAIGN_MONITOR_API_KEY"},
+    client_id: {:system, "CAMPAIGN_MONITOR_CLIENT_ID"}
+  }
 
   defmodule FakeCampaignMonitor do
     use Plug.Router
@@ -133,7 +137,7 @@ defmodule Bamboo.CampaignMonitorAdapterTest do
     email |> CampaignMonitorAdapter.deliver(@config)
 
     assert_receive {:fake_campaign_monitor, %{params: params}}
-    
+
     assert params["To"] == ["To <to@bar.com>", "noname@bar.com"]
     assert params["BCC"] == ["BCC <bcc@bar.com>"]
     assert params["CC"] == ["CC <cc@bar.com>"]
@@ -155,7 +159,7 @@ defmodule Bamboo.CampaignMonitorAdapterTest do
     email |> CampaignMonitorAdapter.deliver(@config)
 
     assert_receive {:fake_campaign_monitor, %{params: params}}
-    assert params["ReplyTo"] == "foo@bar.com" 
+    assert params["ReplyTo"] == "foo@bar.com"
   end
 
   test "raises if the response is not a success" do


### PR DESCRIPTION
Hey 👋
We've needed to migrate from SendGrid to Campaign Monitor, so we've written an adapter for it, and largely based it off the SendGrid adapter.

Currently, it supports classic email and smart email, but Smart email is not documented or tested well yet. I wanted to check first to see if this is something you want to add before spending too much time on it, happy to update it before merging too.

https://www.campaignmonitor.com/api/transactional/#send-classic-email
https://www.campaignmonitor.com/api/transactional/#send-smart-email