### PR TITLE
Send headers in Sendgrid Adapter

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -10,6 +10,9 @@ defmodule Bamboo.SendGridAdapter do
 
       put_header("reply-to", "foo@bar.com")
 
+  To set arbitrary email headers, set them in the `headers` property of the [Bamboo.Email](Bamboo.Email) struct.
+  Note that some header names are reserved for use by Sendgrid.
+
   ## Example config
 
       # In config/config.exs, or config.prod.exs, etc.
@@ -98,6 +101,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_from(email)
     |> put_personalization(email)
     |> put_reply_to(email)
+    |> put_headers(email)
     |> put_subject(email)
     |> put_content(email)
     |> put_template_id(email)
@@ -160,6 +164,14 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp put_reply_to(body, _), do: body
+
+  defp put_headers(body, %Email{headers: headers}) when is_map(headers) do
+    prepared_headers = Map.delete(headers, "reply-to")
+
+    Map.put(body, :headers, prepared_headers)
+  end
+
+  defp put_headers(body, _), do: body
 
   defp put_subject(body, %Email{subject: subject}) when not is_nil(subject),
     do: Map.put(body, :subject, subject)

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -168,7 +168,8 @@ defmodule Bamboo.SendGridAdapter do
 
   defp put_headers(body, %Email{headers: headers}) when is_map(headers) do
     headers_without_tuple_values =
-      Map.delete(headers, "reply-to")
+      headers
+      |> Map.delete("reply-to")
       |> Map.delete("Reply-To")
 
     Map.put(body, :headers, headers_without_tuple_values)

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -167,9 +167,11 @@ defmodule Bamboo.SendGridAdapter do
   defp put_reply_to(body, _), do: body
 
   defp put_headers(body, %Email{headers: headers}) when is_map(headers) do
-    prepared_headers = Map.delete(headers, "reply-to")
+    headers_without_tuple_values =
+      Map.delete(headers, "reply-to")
+      |> Map.delete("Reply-To")
 
-    Map.put(body, :headers, prepared_headers)
+    Map.put(body, :headers, headers_without_tuple_values)
   end
 
   defp put_headers(body, _), do: body

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -11,7 +11,8 @@ defmodule Bamboo.SendGridAdapter do
       put_header("reply-to", "foo@bar.com")
 
   To set arbitrary email headers, set them in the `headers` property of the [Bamboo.Email](Bamboo.Email) struct.
-  Note that some header names are reserved for use by Sendgrid.
+  Note that some header names are reserved for use by Sendgrid. See
+  [here](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html) for full list.
 
   ## Example config
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -332,6 +332,19 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["reply_to"] == %{"email" => "foo@bar.com", "name" => "Foo Bar"}
   end
 
+  test "deliver/2 correctly sends headers" do
+    email = new_email(headers: %{
+      "In-Reply-To" => "message_id",
+      "References" => "message_id"
+    })
+
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["headers"] ==
+      %{"In-Reply-To" => "message_id", "References" => "message_id"}
+  end
+
   test "deliver/2 omits attachments key if no attachments" do
     email = new_email()
     email |> SendGridAdapter.deliver(@config)

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -333,16 +333,20 @@ defmodule Bamboo.SendGridAdapterTest do
   end
 
   test "deliver/2 correctly sends headers" do
-    email = new_email(headers: %{
-      "In-Reply-To" => "message_id",
-      "References" => "message_id"
-    })
+    email =
+      new_email(
+        headers: %{
+          "In-Reply-To" => "message_id",
+          "References" => "message_id"
+        }
+      )
 
     email |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
+
     assert params["headers"] ==
-      %{"In-Reply-To" => "message_id", "References" => "message_id"}
+             %{"In-Reply-To" => "message_id", "References" => "message_id"}
   end
 
   test "deliver/2 omits attachments key if no attachments" do

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -349,6 +349,24 @@ defmodule Bamboo.SendGridAdapterTest do
              %{"In-Reply-To" => "message_id", "References" => "message_id"}
   end
 
+  test "deliver/2 removes 'reply-to' and 'Reply-To' headers" do
+    email =
+      new_email(
+        headers: %{
+          "X-Custom-Header" => "ohai",
+          "Reply-To" => "something",
+          "reply-to" => {"a", "tuple"}
+        }
+      )
+
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+
+    refute Map.has_key?(params["headers"], "Reply-To")
+    refute Map.has_key?(params["headers"], "reply-to")
+  end
+
   test "deliver/2 omits attachments key if no attachments" do
     email = new_email()
     email |> SendGridAdapter.deliver(@config)


### PR DESCRIPTION
Implements #445. Allows arbitrary setting of Sendgrid email headers through `Bamboo.Email`'s `headers` field.

Detailed documentation on Sendgrid's support for email headers here: https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html