### PR TITLE
SendGrid Adapter Reply-To parameter updates

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -146,6 +146,10 @@ defmodule Bamboo.SendGridAdapter do
     Map.put(body, :reply_to, %{email: reply_to})
   end
 
+  defp put_reply_to(body, %Email{headers: %{"Reply-To" => reply_to}}) do
+    Map.put(body, :reply_to, %{email: reply_to})
+  end
+
   defp put_reply_to(body, _), do: body
 
   defp put_subject(body, %Email{subject: subject}) when not is_nil(subject),

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -142,8 +142,16 @@ defmodule Bamboo.SendGridAdapter do
     put_addresses(body, :bcc, bcc)
   end
 
+  defp put_reply_to(body, %Email{headers: %{"reply-to" => {name, email}}}) do
+    Map.put(body, :reply_to, %{email: email, name: name})
+  end
+
   defp put_reply_to(body, %Email{headers: %{"reply-to" => reply_to}}) do
     Map.put(body, :reply_to, %{email: reply_to})
+  end
+
+  defp put_reply_to(body, %Email{headers: %{"Reply-To" => {name, email}}}) do
+    Map.put(body, :reply_to, %{email: email, name: name})
   end
 
   defp put_reply_to(body, %Email{headers: %{"Reply-To" => reply_to}}) do

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -256,6 +256,24 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["reply_to"] == %{"email" => "foo@bar.com"}
   end
 
+  test "deliver/2 correctly formats Reply-To from headers with name and email" do
+    email = new_email(headers: %{"Reply-To" => {"Foo Bar", "foo@bar.com"}})
+
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["reply_to"] == %{"email" => "foo@bar.com", "name" => "Foo Bar"}
+  end
+
+  test "deliver/2 correctly formats reply-to from headers with name and email" do
+    email = new_email(headers: %{"reply-to" => {"Foo Bar", "foo@bar.com"}})
+
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["reply_to"] == %{"email" => "foo@bar.com", "name" => "Foo Bar"}
+  end
+
   test "deliver/2 omits attachments key if no attachments" do
     email = new_email()
     email |> SendGridAdapter.deliver(@config)

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -247,6 +247,15 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["reply_to"] == %{"email" => "foo@bar.com"}
   end
 
+  test "deliver/2 correctly formats Reply-To from headers" do
+    email = new_email(headers: %{"Reply-To" => "foo@bar.com"})
+
+    email |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["reply_to"] == %{"email" => "foo@bar.com"}
+  end
+
   test "deliver/2 omits attachments key if no attachments" do
     email = new_email()
     email |> SendGridAdapter.deliver(@config)


### PR DESCRIPTION
This PR adds support for the "native" `Reply-To` header string (in addition to the already supported custom `reply-to` header string).

Additionally, it also adds full support for SendGrids `reply_to` parameter format with both the required `email` field and optional `name` field.

I split these two additions into 2 separate commits for easier review and editing.  If there is no desire to add full support for the `name` field, I can gladly drop that commit and just send across the `Reply-To` commit. 

To me, at a minimum, the `Reply-To` format of the header string should be allowed as this is the standard name for the header in SMTP spec and is referenced directly in the top level `Bamboo.Email` docs on the `put_header/3` function. 