### PR TITLE
Mailgun Adapter: Config driven base uri

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -11,7 +11,8 @@ defmodule Bamboo.MailgunAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.MailgunAdapter,
         api_key: "my_api_key" # or {:system, "MAILGUN_API_KEY"},
-        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"}
+        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"},
+        base_url: "https://api.eu.mailgun.net/v3" # Optional
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
@@ -20,7 +21,6 @@ defmodule Bamboo.MailgunAdapter do
   """
 
   @service_name "Mailgun"
-  @base_uri "https://api.mailgun.net/v3"
   @behaviour Bamboo.Adapter
 
   alias Bamboo.{Email, Attachment}
@@ -81,8 +81,8 @@ defmodule Bamboo.MailgunAdapter do
   def supports_attachments?, do: true
 
   defp full_uri(config) do
-    Application.get_env(:bamboo, :mailgun_base_uri, @base_uri) <>
-      "/" <> config.domain <> "/messages"
+    base_uri = Application.get_env(:bamboo, :mailgun_base_uri, config.base_uri)
+    base_uri <> "/" <> config.domain <> "/messages"
   end
 
   defp headers(%Email{} = email, config) do

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -41,6 +41,7 @@ defmodule Bamboo.MailgunAdapter do
   """
 
   @service_name "Mailgun"
+  @default_base_uri "https://api.mailgun.net/v3"
   @behaviour Bamboo.Adapter
 
   alias Bamboo.{Email, Attachment}
@@ -51,11 +52,11 @@ defmodule Bamboo.MailgunAdapter do
     config
     |> Map.put(:api_key, get_setting(config, :api_key))
     |> Map.put(:domain, get_setting(config, :domain))
-    |> Map.put_new(:base_uri, default_base_uri())
+    |> Map.put_new(:base_uri, base_uri())
   end
 
-  defp default_base_uri() do
-    Application.get_env(:bamboo, :mailgun_base_uri, "https://api.mailgun.net/v3")
+  defp base_uri() do
+    Application.get_env(:bamboo, :mailgun_base_uri, @default_base_uri)
   end
 
   defp get_setting(config, key) do

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -12,12 +12,32 @@ defmodule Bamboo.MailgunAdapter do
         adapter: Bamboo.MailgunAdapter,
         api_key: "my_api_key" # or {:system, "MAILGUN_API_KEY"},
         domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"},
-        base_url: "https://api.eu.mailgun.net/v3" # Optional
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
         use Bamboo.Mailer, otp_app: :my_app
       end
+
+  ## API base URI configuration
+
+  Mailgun makes a difference in the API base URL between sender
+  domains from within the EU and outside.
+
+  By default, the base URL is set to `https://api.mailgun.net/v3`.
+  To override this globally, you can use the Application environment:
+
+      Application.put_env(:bamboo, :mailgun_base_uri, "https://api.eu.mailgun.net/v3")
+
+  However, for advanced configurations (for instance, for multi-tenant
+  setups where you pass in the adapter config when a mail is sent),
+  you might want to specify this on the adapter level:
+
+      config :my_app, MyApp.Mailer,
+        adapter: Bamboo.MailgunAdapter,
+        api_key: "my_api_key",
+        domain: "your.domain",
+        base_uri: "https://api.eu.mailgun.net/v3"
+
   """
 
   @service_name "Mailgun"
@@ -31,6 +51,11 @@ defmodule Bamboo.MailgunAdapter do
     config
     |> Map.put(:api_key, get_setting(config, :api_key))
     |> Map.put(:domain, get_setting(config, :domain))
+    |> Map.put_new(:base_uri, default_base_uri())
+  end
+
+  defp default_base_uri() do
+    Application.get_env(:bamboo, :mailgun_base_uri, "https://api.mailgun.net/v3")
   end
 
   defp get_setting(config, key) do
@@ -81,8 +106,7 @@ defmodule Bamboo.MailgunAdapter do
   def supports_attachments?, do: true
 
   defp full_uri(config) do
-    base_uri = Application.get_env(:bamboo, :mailgun_base_uri, config.base_uri)
-    base_uri <> "/" <> config.domain <> "/messages"
+    config.base_uri <> "/" <> config.domain <> "/messages"
   end
 
   defp headers(%Email{} = email, config) do

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -29,7 +29,7 @@ defmodule Bamboo.MailgunAdapter do
       Application.put_env(:bamboo, :mailgun_base_uri, "https://api.eu.mailgun.net/v3")
 
   However, for advanced configurations (for instance, for multi-tenant
-  setups where you pass in the adapter config when a mail is sent),
+  setups where you pass in the adapter config when an email is sent),
   you might want to specify this on the adapter level:
 
       config :my_app, MyApp.Mailer,

--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -11,7 +11,7 @@ defmodule Bamboo.MailgunAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.MailgunAdapter,
         api_key: "my_api_key" # or {:system, "MAILGUN_API_KEY"},
-        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"},
+        domain: "your.domain" # or {:system, "MAILGUN_DOMAIN"}
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -120,6 +120,21 @@ defmodule Bamboo.MailgunAdapterTest do
     System.delete_env("MAILGUN_API_KEY")
   end
 
+  test "see if defaults base_uri is set" do
+    assert MailgunAdapter.handle_config(%{
+             api_key: "dummyapikey",
+             domain: "test.tt"
+           }).base_uri == "https://api.mailgun.net/v3"
+  end
+
+  test "see if given base_uri is set" do
+    assert MailgunAdapter.handle_config(%{
+             api_key: "dummyapikey",
+             domain: "test.tt",
+             base_uri: "https://api.eu.mailgun.net/v3"
+           }).base_uri == "https://api.eu.mailgun.net/v3"
+  end
+
   test "deliver/2 sends the to the right url" do
     new_email() |> MailgunAdapter.deliver(@config)
 

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -120,7 +120,7 @@ defmodule Bamboo.MailgunAdapterTest do
     System.delete_env("MAILGUN_API_KEY")
   end
 
-  test "see if defaults base_uri is set" do
+  test "see if default base_uri is set" do
     Application.delete_env(:bamboo, :mailgun_base_uri)
 
     assert MailgunAdapter.handle_config(%{

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -121,6 +121,8 @@ defmodule Bamboo.MailgunAdapterTest do
   end
 
   test "see if defaults base_uri is set" do
+    Application.delete_env(:bamboo, :mailgun_base_uri)
+
     assert MailgunAdapter.handle_config(%{
              api_key: "dummyapikey",
              domain: "test.tt"
@@ -133,6 +135,16 @@ defmodule Bamboo.MailgunAdapterTest do
              domain: "test.tt",
              base_uri: "https://api.eu.mailgun.net/v3"
            }).base_uri == "https://api.eu.mailgun.net/v3"
+  end
+
+  test "adapter-level base_uri overrules application env config" do
+    Application.put_env(:bamboo, :mailgun_base_uri, "https://application")
+
+    assert MailgunAdapter.handle_config(%{
+             api_key: "dummyapikey",
+             domain: "test.tt",
+             base_uri: "https://adapter"
+           }).base_uri == "https://adapter"
   end
 
   test "deliver/2 sends the to the right url" do


### PR DESCRIPTION
This PR is a followup to #431, which was not merged but closed.

I think it is still a good change however, thanks @pierot for getting this started.

in this PR, I rebased the original PR onto the new master, added documentation for the base URI config, and ensured that the adapter-level configuration overrules the application environment configuration, when set.