### PR TITLE
[sent_email_viewer] Remove whitespaces inside pre tag

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -183,9 +183,7 @@
           </p>
 
           <h3 class="email-detail-body-label">Text Body</h3>
-          <pre class="email-detail-body">
-            <%= @selected_email.text_body %>
-          </pre>
+          <pre class="email-detail-body"><%= @selected_email.text_body %></pre>
         </section>
       </section>
     </main>


### PR DESCRIPTION
Inside `<pre>` tags, whitespaces are shown literally. Thus rendered text bodies were "indented".

This PR removes whitespaces for indentation in `<pre>` tag from HTML-EEx source code.