### PR TITLE
Fix variable substitution for nested maps in Mailgun templates

### DIFF
--- a/test/lib/bamboo/adapters/mailgun_helper_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_helper_test.exs
@@ -50,13 +50,14 @@ defmodule Bamboo.MailgunHelperTest do
       |> MailgunHelper.substitute_variables(%{"var2" => "val2", "var3" => "val3"})
       |> MailgunHelper.substitute_variables("var4", "val4")
 
-    assert email.private == %{
-             mailgun_custom_vars: %{
-               "var1" => "val1",
-               "var2" => "val2",
-               "var3" => "val3",
-               "var4" => "val4"
-             }
-           }
+    assert email.headers
+           |> Map.get("X-Mailgun-Variables")
+           |> Bamboo.json_library().decode!()
+           |> Map.equal?(%{
+             "var1" => "val1",
+             "var2" => "val2",
+             "var3" => "val3",
+             "var4" => "val4"
+           })
   end
 end


### PR DESCRIPTION
The previous implementation for `Bamboo.MailgunHelper.substitute_variables/2`
seems that does not handle correctly nested maps:

```elixir
private: %{
  mailgun_custom_vars: %{
    campaign: %{name: "ex"},
    from: %{first_name: "Zoe"},
    to: %{first_name: "Theron"}
  },
  "o:tag": "notices",
  template: "thanks"
},
```

Reviewing the logs from Mailgun I saw the following JSON structure:

```json
"user-variables": {
  "from[first_name]": "Zoe",
  "to[first_name]": "Theron",
  "campaign[name]": "ex"
}
```

Which wasn't expected by the Handlebars template, but, I found that you could
use the header `X-Mailgun-Variables` to inject deeply nested maps from Bamboo, and
that's what this proposal includes.

Also, according to the Mailgun documentation when you use a template, you can also use the option: `t:text = yes` to pass the rendered template as the `text` part of the message. Should we include this option on the `MailgunHelper` module?

> | Parameter | Description |
> | ---------- | ------------ | 
> | t:text | Pass yes if you want to have rendered template in the text part of the message in case of template sending |

Regarding the last point, seems that doing `Email.put_private(:"t:text", "yes")` does not work as expected, anyone has tested this feature from Mailgun using Bamboo? I also tried using the header: `X-Mailgun-Template-Text` with `true` as value. @mstratman Have you worked with this option from Mailgun?