### PR TITLE
Allow Dynamic Override of Mailer Config

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -281,8 +281,6 @@ defmodule Bamboo.Mailer do
   end
 
   def build_config(mailer, otp_app, optional_overrides \\ %{}) do
-    optional_overrides = Enum.into(optional_overrides, %{})
-
     otp_app
     |> Application.fetch_env!(mailer)
     |> Map.new()

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -77,13 +77,14 @@ defmodule Bamboo.Mailer do
 
       otp_app = Keyword.fetch!(opts, :otp_app)
 
-      defp build_config([config: dynamic_config_overrides]) do
+      defp build_config(config: dynamic_config_overrides) do
         Bamboo.Mailer.build_config(
           __MODULE__,
           unquote(otp_app),
           dynamic_config_overrides
         )
       end
+
       defp build_config(_) do
         Bamboo.Mailer.build_config(__MODULE__, unquote(otp_app))
       end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -65,19 +65,28 @@ defmodule Bamboo.Mailer do
     quote bind_quoted: [opts: opts] do
       @spec deliver_now(Bamboo.Email.t(), Enum.t()) :: Bamboo.Email.t() | {any, Bamboo.Email.t()}
       def deliver_now(email, opts \\ []) do
-        config = build_config()
+        config = build_config(opts)
         Bamboo.Mailer.deliver_now(config.adapter, email, config, opts)
       end
 
       @spec deliver_later(Bamboo.Email.t()) :: Bamboo.Email.t()
-      def deliver_later(email) do
-        config = build_config()
+      def deliver_later(email, opts \\ []) do
+        config = build_config(opts)
         Bamboo.Mailer.deliver_later(config.adapter, email, config)
       end
 
       otp_app = Keyword.fetch!(opts, :otp_app)
 
-      defp build_config, do: Bamboo.Mailer.build_config(__MODULE__, unquote(otp_app))
+      defp build_config([config: dynamic_config_overrides]) do
+        Bamboo.Mailer.build_config(
+          __MODULE__,
+          unquote(otp_app),
+          dynamic_config_overrides
+        )
+      end
+      defp build_config(_) do
+        Bamboo.Mailer.build_config(__MODULE__, unquote(otp_app))
+      end
 
       @spec deliver(any()) :: no_return()
       def deliver(_email) do
@@ -102,6 +111,12 @@ defmodule Bamboo.Mailer do
   access to any data sent back from your email provider in the response.
 
       Email.welcome_email |> Mailer.deliver_now(response: true)
+
+  Pass in an argument of `config: %{}` if you would like to dynamically override
+  any keys in your application's default Mailer configuration.
+
+      Email.welcome_email
+      |> Mailer.deliver_now(config: %{username: "Emma", smtp_port: 2525})
   """
   def deliver_now(_email, _opts \\ []) do
     raise @cannot_call_directly_error
@@ -116,7 +131,7 @@ defmodule Bamboo.Mailer do
   `Bamboo.DeliverLaterStrategy` to learn how to change how emails are delivered
   with `deliver_later/1`.
   """
-  def deliver_later(_email) do
+  def deliver_later(_email, _opts \\ []) do
     raise @cannot_call_directly_error
   end
 
@@ -264,10 +279,13 @@ defmodule Bamboo.Mailer do
     build_config(mailer, otp_app)
   end
 
-  def build_config(mailer, otp_app) do
+  def build_config(mailer, otp_app, optional_overrides \\ %{}) do
+    optional_overrides = Enum.into(optional_overrides, %{})
+
     otp_app
     |> Application.fetch_env!(mailer)
     |> Map.new()
+    |> Map.merge(optional_overrides)
     |> handle_adapter_config
   end
 

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -277,7 +277,7 @@ defmodule Bamboo.MailerTest do
         something: :groovy
       }
 
-      Mailer.deliver_now(email, config: override_config)
+      Mailer.deliver_later(email, config: override_config)
 
       assert_received {:deliver, _email, config}
       assert config.foo == :qux

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -256,6 +256,7 @@ defmodule Bamboo.MailerTest do
 
     test "deliver_now/2 overrides Adapter config with the 'config:' option" do
       email = new_email(to: "foo@bar.com")
+
       override_config = %{
         foo: :baz,
         something: :new
@@ -270,6 +271,7 @@ defmodule Bamboo.MailerTest do
 
     test "deliver_later/2 overrides Adapter config with the 'config:' option" do
       email = new_email(to: "baz@qux.com")
+
       override_config = %{
         foo: :qux,
         something: :groovy

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -279,7 +279,7 @@ defmodule Bamboo.MailerTest do
 
       Mailer.deliver_later(email, config: override_config)
 
-      assert_received {:deliver, _email, config}
+      assert_receive {:deliver, _email, config}
       assert config.foo == :qux
       assert config.something == :groovy
     end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -253,6 +253,34 @@ defmodule Bamboo.MailerTest do
       assert_received {:deliver, _email, config}
       assert config.custom_key == "Set by the adapter"
     end
+
+    test "deliver_now/2 overrides Adapter config with the 'config:' option" do
+      email = new_email(to: "foo@bar.com")
+      override_config = %{
+        foo: :baz,
+        something: :new
+      }
+
+      Mailer.deliver_now(email, config: override_config)
+
+      assert_received {:deliver, _email, config}
+      assert config.foo == :baz
+      assert config.something == :new
+    end
+
+    test "deliver_later/2 overrides Adapter config with the 'config:' option" do
+      email = new_email(to: "baz@qux.com")
+      override_config = %{
+        foo: :qux,
+        something: :groovy
+      }
+
+      Mailer.deliver_now(email, config: override_config)
+
+      assert_received {:deliver, _email, config}
+      assert config.foo == :qux
+      assert config.something == :groovy
+    end
   end
 
   describe "option to return response" do


### PR DESCRIPTION
:woman_technologist: Bamboo's adopters would like to be able to pass dynamic configuration
into a single email delivery call, for scenarios such as un/pw, port
changes, or multi-tenancy.

:mailbox_with_mail: This change will update `Bamboo.Mailer` `__using__` macro to allow passing
of optional `config:` keyword to the `build_config/1` function. `build_config/1`
now pattern matches on `config:`, and will pass the value to
`Bamboo.Mailer.build_config/3`. This function will then merge the
dynamic configuration with the default configuration.

:octocat: See #470