### PR TITLE
Add Mailgun template version and template text options

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -135,6 +135,8 @@ defmodule Bamboo.MailgunAdapter do
     |> put_headers(email)
     |> put_tag(email)
     |> put_template(email)
+    |> put_template_version(email)
+    |> put_template_text(email)
     |> put_custom_vars(email)
     |> filter_non_empty_mailgun_fields
     |> encode_body
@@ -189,6 +191,18 @@ defmodule Bamboo.MailgunAdapter do
 
   defp put_template(body, %Email{}), do: body
 
+  defp put_template_version(body, %Email{private: %{:"t:version" => template_version}}) do
+    Map.put(body, :"t:version", template_version)
+  end
+
+  defp put_template_version(body, %Email{}), do: body
+
+  defp put_template_text(body, %Email{private: %{:"t:text" => true}}) do
+    Map.put(body, :"t:text", "yes")
+  end
+
+  defp put_template_text(body, %Email{}), do: body
+
   defp put_custom_vars(body, %Email{private: private}) do
     custom_vars = Map.get(private, :mailgun_custom_vars, %{})
 
@@ -220,7 +234,7 @@ defmodule Bamboo.MailgunAdapter do
     Enum.filter(body, fn {key, value} ->
       # Key is a well known mailgun field (including header and custom var field) and its value is not empty
       (key in @mailgun_message_fields || key in @internal_fields ||
-         String.starts_with?(Atom.to_string(key), ["h:", "v:", "o:"])) &&
+         String.starts_with?(Atom.to_string(key), ["h:", "v:", "o:", "t:"])) &&
         !(value in [nil, "", []])
     end)
     |> Enum.into(%{})

--- a/lib/bamboo/adapters/mailgun_helper.ex
+++ b/lib/bamboo/adapters/mailgun_helper.ex
@@ -35,6 +35,35 @@ defmodule Bamboo.MailgunHelper do
   end
 
   @doc """
+  Use it to send a message to specific version of a template.
+
+  More details can be found in the
+  [Mailgun documentation](https://documentation.mailgun.com/en/latest/api-sending.html#sending)
+
+  ## Example
+
+      email
+      |> MailgunHelper.template("my-template")
+      |> MailgunHelper.template_version("v2")
+  """
+  def template_version(email, version), do: Email.put_private(email, :"t:version", version)
+
+  @doc """
+  Use it if you want to have rendered template in the text part of the
+  message in case of template sending.
+
+  More details can be found in the
+  [Mailgun documentation](https://documentation.mailgun.com/en/latest/api-sending.html#sending)
+
+  ## Example
+
+      email
+      |> MailgunHelper.template_text(true)
+  """
+  def template_text(email, true), do: Email.put_private(email, :"t:text", true)
+  def template_text(email, _), do: Email.put_private(email, :"t:text", false)
+
+  @doc """
   When sending an email with `Bamboo.MailgunHelper.template/2` you can
   replace a handlebars variables using this function.
 
@@ -46,7 +75,7 @@ defmodule Bamboo.MailgunHelper do
       email
       |> MailgunHelper.template("password-reset-email")
       |> MailgunHelper.substitute_variables("password_reset_link", "https://example.com/123")
-    
+
   """
   def substitute_variables(email, key, value) do
     substitute_variables(email, %{key => value})
@@ -61,7 +90,7 @@ defmodule Bamboo.MailgunHelper do
       email
       |> MailgunHelper.template("password-reset-email")
       |> MailgunHelper.substitute_variables(%{ "greeting" => "Hello!", "password_reset_link" => "https://example.com/123" })
-    
+
   """
   def substitute_variables(email, variables = %{}) do
     custom_vars = Map.get(email.private, :mailgun_custom_vars, %{})

--- a/test/lib/bamboo/adapters/mailgun_adapter_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_adapter_test.exs
@@ -258,6 +258,27 @@ defmodule Bamboo.MailgunAdapterTest do
     assert params["h:Reply-To"] == "random@foo.com"
   end
 
+  test "deliver/2 correctly formats template and template options" do
+    email =
+      new_email(
+        from: "from@foo.com",
+        subject: "My Subject",
+        text_body: "TEXT BODY",
+        html_body: "HTML BODY"
+      )
+      |> Email.put_private(:template, "my_template")
+      |> Email.put_private(:"t:version", "v2")
+      |> Email.put_private(:"t:text", true)
+
+    MailgunAdapter.deliver(email, @config)
+
+    assert_receive {:fake_mailgun, %{params: params}}
+
+    assert params["template"] == "my_template"
+    assert params["t:version"] == "v2"
+    assert params["t:text"] == "yes"
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 

--- a/test/lib/bamboo/adapters/mailgun_helper_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_helper_test.exs
@@ -17,6 +17,26 @@ defmodule Bamboo.MailgunHelperTest do
     assert email.private == %{template: "welcome"}
   end
 
+  test "adds template version to mailgun emails" do
+    email = new_email() |> MailgunHelper.template_version("v2")
+    assert email.private == %{:"t:version" => "v2"}
+  end
+
+  test "enables template text" do
+    email = new_email() |> MailgunHelper.template_text(true)
+    assert email.private == %{:"t:text" => true}
+  end
+
+  test "disables template text" do
+    email = new_email() |> MailgunHelper.template_text(false)
+    assert email.private == %{:"t:text" => false}
+  end
+
+  test "disables template text with wrong arg" do
+    email = new_email() |> MailgunHelper.template_text("string")
+    assert email.private == %{:"t:text" => false}
+  end
+
   test "adds template substitution variables to mailgun emails" do
     email =
       new_email()


### PR DESCRIPTION
Added 2 template options for Mailgun.

Parameter  | Description
---------- | ---------
 t:version | Use this parameter to send a message to specific version of a template |
 t:text    | Pass `yes` if you want to have rendered template in the text part of the message in case of template sending |


More info is here https://documentation.mailgun.com/en/latest/api-sending.html#sending
