### PR TITLE
Implement Mailgun's o:deliverytime to schedule email delivery

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -134,6 +134,7 @@ defmodule Bamboo.MailgunAdapter do
     |> put_attachments(email)
     |> put_headers(email)
     |> put_tag(email)
+    |> put_deliverytime(email)
     |> put_template(email)
     |> put_custom_vars(email)
     |> filter_non_empty_mailgun_fields
@@ -183,6 +184,11 @@ defmodule Bamboo.MailgunAdapter do
 
   defp put_tag(body, %Email{private: %{:"o:tag" => tag}}), do: Map.put(body, :"o:tag", tag)
   defp put_tag(body, %Email{}), do: body
+
+  defp put_deliverytime(body, %Email{private: %{:"o:deliverytime" => deliverytime}}),
+    do: Map.put(body, :"o:deliverytime", deliverytime)
+
+  defp put_deliverytime(body, %Email{}), do: body
 
   defp put_template(body, %Email{private: %{template: template}}),
     do: Map.put(body, :template, template)

--- a/lib/bamboo/adapters/mailgun_helper.ex
+++ b/lib/bamboo/adapters/mailgun_helper.ex
@@ -24,6 +24,25 @@ defmodule Bamboo.MailgunHelper do
   end
 
   @doc """
+  Schedule an email to be delivered in the future.
+
+  More details can be found in the
+  [Mailgun documentation](https://documentation.mailgun.com/en/latest/user_manual.html#scheduling-delivery)
+
+  ## Example
+
+      one_hour_from_now =
+        DateTime.utc_now()
+        |> DateTime.add(3600)
+
+      email
+      |> MailgunHelper.deliverytime(one_hour_from_now)
+  """
+  def deliverytime(email, %DateTime{} = deliverytime) do
+    Email.put_private(email, :"o:deliverytime", DateTime.to_unix(deliverytime))
+  end
+
+  @doc """
   Send an email using a template stored in Mailgun, rather than supplying
   a `Bamboo.Email.text_body/2` or a `Bamboo.Email.html_body/2`.
 
@@ -46,7 +65,7 @@ defmodule Bamboo.MailgunHelper do
       email
       |> MailgunHelper.template("password-reset-email")
       |> MailgunHelper.substitute_variables("password_reset_link", "https://example.com/123")
-    
+
   """
   def substitute_variables(email, key, value) do
     substitute_variables(email, %{key => value})
@@ -61,7 +80,7 @@ defmodule Bamboo.MailgunHelper do
       email
       |> MailgunHelper.template("password-reset-email")
       |> MailgunHelper.substitute_variables(%{ "greeting" => "Hello!", "password_reset_link" => "https://example.com/123" })
-    
+
   """
   def substitute_variables(email, variables = %{}) do
     custom_vars = Map.get(email.private, :mailgun_custom_vars, %{})

--- a/test/lib/bamboo/adapters/mailgun_helper_test.exs
+++ b/test/lib/bamboo/adapters/mailgun_helper_test.exs
@@ -9,6 +9,13 @@ defmodule Bamboo.MailgunHelperTest do
     assert Map.get(Map.get(email, :private, %{}), :"o:tag", nil) == "new-tag"
   end
 
+  test "deliverytime/2 puts a deliverytime in private" do
+    email = new_email() |> MailgunHelper.deliverytime(~U[2015-01-23 23:50:07Z])
+
+    # DateTime.to_unix(~U[2015-01-23 23:50:07Z]) == 1_422_057_007
+    assert Map.get(Map.get(email, :private, %{}), :"o:deliverytime", nil) == 1_422_057_007
+  end
+
   test "adds template information to mailgun emails" do
     email =
       new_email()


### PR DESCRIPTION
Mailgun has a handy o:deliverytime property which allows you to schedule email delivery in the future.

Personally I needed it to send a feedback request email after users complete some task.

Here is a quick example:

```elixir
one_hour_from_now =
  DateTime.utc_now()
  |> DateTime.add(3600)
  
email
  |> MailgunHelper.deliverytime(one_hour_from_now)
```