### PR TITLE
Support SendGrid send_at field

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Mandrill offers extra features on top of regular SMTP email like tagging, merge
 vars, templates, and scheduling emails to send in the future. See
 [`Bamboo.MandrillHelper`].
 
-## SendGrid Specific Functionality (templates and substitution tags)
+## SendGrid Specific Functionality (templates, substitution tags, scheduled delivery, etc.)
 
 SendGrid offers extra features on top of regular SMTP email like transactional
 templates with substitution tags. See [`Bamboo.SendGridHelper`].

--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -111,6 +111,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_template_id(email)
     |> put_attachments(email)
     |> put_categories(email)
+    |> put_send_at(email)
     |> put_settings(config)
     |> put_asm_group_id(email)
     |> put_bypass_list_management(email)
@@ -259,6 +260,13 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp put_categories(body, _), do: body
+
+  defp put_send_at(body, %Email{private: %{sendgrid_send_at: send_at_timestamp}}) do
+    body
+    |> Map.put(:send_at, send_at_timestamp)
+  end
+
+  defp put_send_at(body, _), do: body
 
   defp put_asm_group_id(body, %Email{private: %{asm_group_id: asm_group_id}})
        when is_integer(asm_group_id) do

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -19,6 +19,7 @@ defmodule Bamboo.SendGridHelper do
   @google_analytics_enabled :google_analytics_enabled
   @google_analytics_utm_params :google_analytics_utm_params
   @allowed_google_analytics_utm_params ~w(utm_source utm_medium utm_campaign utm_term utm_content)a
+  @send_at_field :sendgrid_send_at
 
   @doc """
   Specify the template for SendGrid to use for the context of the substitution
@@ -188,6 +189,17 @@ defmodule Bamboo.SendGridHelper do
 
   def with_google_analytics(_email, _enabled, _utm_params) do
     raise "expected with_google_analytics enabled parameter to be a boolean"
+  end
+
+  def with_send_at(email, %DateTime{} = time) do
+    timestamp = DateTime.to_unix(time)
+
+    email
+    |> Email.put_private(@send_at_field, timestamp)
+  end
+
+  def with_send_at(_email, _time) do
+    raise "expected with_send_at time parameter to be a DateTime"
   end
 
   defp set_template(template, template_id) do

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -204,6 +204,7 @@ defmodule Bamboo.SendGridHelper do
       email
       |> with_send_at(delivery_time)
   """
+  @spec with_send_at(%Email{}, %DateTime{} | integer()) :: %Email{}
   def with_send_at(email, %DateTime{} = time) do
     timestamp = DateTime.to_unix(time)
 
@@ -211,8 +212,13 @@ defmodule Bamboo.SendGridHelper do
     |> Email.put_private(@send_at_field, timestamp)
   end
 
+  def with_send_at(email, unix_timestamp) when is_integer(unix_timestamp) do
+    email
+    |> Email.put_private(@send_at_field, unix_timestamp)
+  end
+
   def with_send_at(_email, _time) do
-    raise "expected with_send_at time parameter to be a DateTime"
+    raise "expected with_send_at time parameter to be a DateTime or unix timestamp"
   end
 
   defp set_template(template, template_id) do

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -191,6 +191,19 @@ defmodule Bamboo.SendGridHelper do
     raise "expected with_google_analytics enabled parameter to be a boolean"
   end
 
+  @doc """
+  Schedule a time for SendGrid to deliver the email.
+
+  Note that if the time is in the past, SendGrid will immediately deliver the
+  email.
+
+  ## Example
+
+      {:ok, delivery_time, _} = DateTime.from_iso8601("2020-01-01T00:00:00Z")
+
+      email
+      |> with_send_at(delivery_time)
+  """
   def with_send_at(email, %DateTime{} = time) do
     timestamp = DateTime.to_unix(time)
 

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -286,6 +286,21 @@ defmodule Bamboo.SendGridAdapterTest do
     assert params["tracking_settings"]["ganalytics"]["utm_content"] == "content"
   end
 
+  test "deliver/2 correctly handles a sendgrid_send_at timestamp" do
+    email =
+      new_email(
+        from: {"From", "from@foo.com"},
+        subject: "My Subject"
+      )
+
+    email
+    |> Bamboo.SendGridHelper.with_send_at(1_580_485_560)
+    |> SendGridAdapter.deliver(@config)
+
+    assert_receive {:fake_sendgrid, %{params: params}}
+    assert params["send_at"] == 1_580_485_560
+  end
+
   test "deliver/2 doesn't force a subject" do
     email = new_email(from: {"From", "from@foo.com"})
 

--- a/test/lib/bamboo/adapters/send_grid_helper_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_helper_test.exs
@@ -181,4 +181,24 @@ defmodule Bamboo.SendGridHelperTest do
       email |> with_google_analytics(1, utm_params)
     end
   end
+
+  describe "with_send_at/2" do
+    test "adds the correct property for a DateTime input", %{email: email} do
+      {:ok, datetime, _} = DateTime.from_iso8601("2020-01-31T15:46:00Z")
+      email = email |> with_send_at(datetime)
+      assert email.private[:sendgrid_send_at] == 1_580_485_560
+    end
+
+    test "adds the correct property for an integer input", %{email: email} do
+      timestamp = 1_580_485_560
+      email = email |> with_send_at(timestamp)
+      assert email.private[:sendgrid_send_at] == 1_580_485_560
+    end
+
+    test "raises on incorrect input", %{email: email} do
+      assert_raise RuntimeError, fn ->
+        email |> with_send_at("truck")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds support for SendGrid's send_at field, according to SendGrid's [guide on scheduling](https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html) and [API reference](https://sendgrid.com/docs/api-reference).

This is useful for scenarios when you need to do a lot of computational work to send a batch of emails, but you want them all delivered at the same time.

Thanks!