### PR TITLE
SendGrid requires an `Accept` header

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -95,6 +95,7 @@ defmodule Bamboo.SendGridAdapter do
 
   defp headers(api_key) do
     [
+      {"Accept", "application/json"},
       {"Content-Type", "application/json"},
       {"Authorization", "Bearer #{api_key}"}
     ]


### PR DESCRIPTION
This header appears to be required [according to the documentation](https://sendgrid.com/docs/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/requests.html#-Accept-Header).

Until I added this, I was getting HTTP 406 errors.