### PR TITLE
Reduce Jason version constraints

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Bamboo.Mixfile do
       {:floki, "~> 0.8", only: :test},
       {:ex_doc, "~> 0.20", only: :dev},
       {:hackney, ">= 1.13.0"},
-      {:jason, "~> 1.1.0", optional: true}
+      {:jason, "~> 1.1", optional: true}
     ]
   end
 end


### PR DESCRIPTION
Otherwise, everyone using Bamboo would have a bad time upgrading other deps that bump Jason to v1.2. Especially in umbrella apps where you need to override version in every single app.