### PR TITLE
Add `assert_email_delivered_matches/1` to test functions

### DIFF
--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -166,6 +166,29 @@ defmodule Bamboo.Test do
   end
 
   @doc """
+  Checks whether an email was delivered matching the given pattern.
+
+  Must be used with the `Bamboo.TestAdapter` or this will never pass. This
+  allows the user to use their configured `assert_receive_timeout` for ExUnit,
+  and also to match any variables in their given pattern for use in further
+  assertions.
+
+  ## Examples
+
+      %{email: user_email, name: user_name} = user
+      MyApp.deliver_welcome_email(user)
+      assert_delivered_email_matches(%{to: [{_, ^user_email}], text_body: text_body})
+      assert text_body =~ "Welcome to MyApp, #\{user_name}"
+      assert text_body =~ "You can sign up at https://my_app.com/users/#\{user_name}"
+  """
+  defmacro assert_delivered_email_matches(email_pattern) do
+    quote do
+      require ExUnit.Assertions
+      ExUnit.Assertions.assert_receive({:delivered_email, unquote(email_pattern)})
+    end
+  end
+
+  @doc """
   Check whether an email's params are equal to the ones provided.
 
   Must be used with the `Bamboo.TestAdapter` or this will never pass. In case you

--- a/test/lib/bamboo/adapters/test_adapter_test.exs
+++ b/test/lib/bamboo/adapters/test_adapter_test.exs
@@ -273,4 +273,23 @@ defmodule Bamboo.TestAdapterTest do
 
     assert_delivered_email(%{email | assigns: :assigns_removed_for_testing})
   end
+
+  test "assert_delivered_email_matches/1 with no delivered emails" do
+    try do
+      assert_delivered_email_matches(%{to: ["foo@bar.com"]})
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert %{} = error
+    else
+      _ -> flunk("assert_delivered_email should failed")
+    end
+  end
+
+  test "assert_delivered_email_matches/1 allows binding of variables for further testing" do
+    sent_email = new_email(from: "foo@bar.com", to: ["foo@bar.com"])
+    TestMailer.deliver_now(sent_email)
+
+    assert_delivered_email_matches(%{to: [{nil, email}]})
+    assert email == "foo@bar.com"
+  end
 end


### PR DESCRIPTION
Right now if one wanted to make pretty comprehensive assertions on a
delivered email, you need to either match the exact email with
`assert_email_delivered/1` or use values or regexes with
`assert_email_delivered_with/1`. The problem with those is that it
doesn't allow you to bind a variable to the email that was delivered,
meaning you need to do all your assertions on that one email in that one
function.

This becomes especially problematic with things like testing the body of
an HTML email, as your option is either an exact match (which is
brittle) or a single regex (which is exceptionally complicated). By
allowing the user to use the match operator to bind variables and then
test those variables after the `assert_email_delivered_matches/1` call,
it can make for much simpler and less brittle tests.

It's a very small implementation - basically all it does is hide the
implementation detail of how the TestAdapter works, which I think is
enough to warrant its existence.

I thought about changing something like `assert_email_delivered/1` to
allow for binding variables in this way, but that would change the
semantics of that function too significantly, so I went with introducing
a new function.