### PR TITLE
Fix passing both response: true and config options

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -65,7 +65,8 @@ defmodule Bamboo.Mailer do
     quote bind_quoted: [opts: opts] do
       @spec deliver_now(Bamboo.Email.t(), Enum.t()) :: Bamboo.Email.t() | {any, Bamboo.Email.t()}
       def deliver_now(email, opts \\ []) do
-        config = build_config(opts)
+        {config, opts} = Keyword.split(opts, [:config])
+        config = build_config(config)
         Bamboo.Mailer.deliver_now(config.adapter, email, config, opts)
       end
 

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -312,6 +312,16 @@ defmodule Bamboo.MailerTest do
 
       assert %Email{} = email
     end
+
+    @tag adapter: ResponseAdapter
+    test "deliver_now/1 returns email and response when passing in both response: true and a custom config option" do
+      email = new_email(to: "foo@bar.com")
+
+      {email, response} = Mailer.deliver_now(email, config: %{}, response: true)
+
+      assert %Email{} = email
+      assert %{body: _, headers: _, status_code: _} = response
+    end
   end
 
   defp new_email(attrs \\ []) do


### PR DESCRIPTION
Passing both `response: true` and `config` options to `deliver_now/2` resulted in a failing pattern match in `build_config/1` and therefore calling the used adapter without any custom overrides provided in `config`.

This issue resulted in the problem mentioned here: https://github.com/fewlinesco/bamboo_smtp/issues/142

Fixes #537 