### PR TITLE
Use api.sendgrid.com instead of non-api version

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -35,7 +35,7 @@ defmodule Bamboo.SendGridAdapter do
   """
 
   @service_name "SendGrid"
-  @default_base_uri "https://sendgrid.com/v3/"
+  @default_base_uri "https://api.sendgrid.com/v3/"
   @send_message_path "/mail/send"
   @behaviour Bamboo.Adapter
 


### PR DESCRIPTION
Closes https://github.com/thoughtbot/bamboo/issues/544

What changed?
=============

Sendgrid's docs state,

> A Host. The host for Web API v3 requests is always https://api.sendgrid.com/v3/

Bamboo has the base uri as https:/sendgrid.com/v3/. It seems that when commit e8e981652998ac1af99b606d66acf10d848fca3d updated to use v3, we somehow lost the `api` portion.

For more see sendgrid's docs: https://sendgrid.com/docs/for-developers/sending-email/api-getting-started/