### PR TITLE
Add space between name and email in mailviewer

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -37,6 +37,6 @@ defmodule Bamboo.SentEmailViewerPlug.Helper do
   def format_email_address({nil, address}), do: address
 
   def format_email_address({name, address}) do
-    "#{name}&lt;#{address}&gt;"
+    "#{name} &lt;#{address}&gt;"
   end
 end


### PR DESCRIPTION
Small cosmetic change, but this is how it's presented in other email clients, most of the time.

<img width="503" alt="Screenshot 2020-08-31 at 19 54 24@2x" src="https://user-images.githubusercontent.com/104180/91750685-cab17900-ebc3-11ea-8bbc-45aad570b302.png">
