### PR TITLE
Show recipient names in mailviewer

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -14,7 +14,7 @@ defmodule Bamboo.SentEmailViewerPlug.Helper do
 
   def email_addresses(email) do
     Bamboo.Email.all_recipients(email)
-    |> Enum.map(&Bamboo.Email.get_address/1)
+    |> Enum.map(&format_email_address/1)
     |> Enum.join(", ")
   end
 


### PR DESCRIPTION
I first thought I did something wrong, but then I noticed that the mailviewer only shows the email addresses. This fixes it:
<img width="602" alt="Screenshot 2020-08-31 at 19 54 06@2x" src="https://user-images.githubusercontent.com/104180/91750736-de5cdf80-ebc3-11ea-9400-cde996ab8adc.png">
