### PR TITLE
Show attachments in viewer

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/email_preview_plug.ex
+++ b/lib/bamboo/plug/sent_email_viewer/email_preview_plug.ex
@@ -70,6 +70,22 @@ defmodule Bamboo.SentEmailViewerPlug do
     end
   end
 
+  get "/:id/attachments/:index" do
+    with %Bamboo.Email{} = email <- SentEmail.get(id),
+         %Bamboo.Attachment{} = attachment <- Enum.at(email.attachments, String.to_integer(index)) do
+      conn
+      |> Plug.Conn.put_resp_header(
+        "content-disposition",
+        "inline; filename=\"#{attachment.filename}\""
+      )
+      |> Plug.Conn.put_resp_content_type(attachment.content_type)
+      |> send_resp(:ok, attachment.data)
+    else
+      _ ->
+        conn |> render_not_found
+    end
+  end
+
   defp all_emails do
     SentEmail.all()
   end

--- a/lib/bamboo/plug/sent_email_viewer/helper.ex
+++ b/lib/bamboo/plug/sent_email_viewer/helper.ex
@@ -47,4 +47,8 @@ defmodule Bamboo.SentEmailViewerPlug.Helper do
   def format_email_address({name, address}) do
     "#{name} &lt;#{address}&gt;"
   end
+
+  def format_attachment(%{filename: filename}) do
+    HTML.html_escape(filename)
+  end
 end

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -220,7 +220,7 @@
                   attachment = Enum.at(@selected_email.attachments, index)
                   href = "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/attachments/#{index}"
                 %>
-                <li><a href="<%= href %>"><%= attachment.filename %></a></li>
+                <li><a href="<%= href %>"><%= Bamboo.SentEmailViewerPlug.Helper.format_attachment(attachment) %></a></li>
               <% end %>
               </ul>
             </span>

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -108,6 +108,41 @@
         padding: 10px 0;
       }
 
+      .email-attachment-icon::after {
+        content: '📎';
+        filter: grayscale(100%);
+      }
+
+      .email-detail-attachments {
+        display: flex;
+        align-items: center;
+        margin: 0.2em 0;
+      }
+
+      .email-detail-attachments-icon-container {
+        margin: 0 0.25em 0 0;
+      }
+
+      .email-detail-attachments ul {
+        display: flex;
+        flex-wrap: wrap;
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .email-detail-attachments ul li {
+        padding-right: 0.25em;
+      }
+
+      .email-detail-attachments ul li:not(:last-of-type)::after {
+        content: ',';
+      }
+
+      .email-detail-attachments ul li a {
+        font-weight: bold;
+      }
+
       .email-detail-bodies-container {
         border: 1px solid #eee;
         border-radius: 5px;
@@ -123,12 +158,14 @@
       }
 
       .email-detail-recipients,
-      .email-detail-headers {
+      .email-detail-headers,
+      .email-detail-attachments {
         color: #aaa;
       }
 
       .email-detail-recipients strong,
-      .email-detail-headers strong {
+      .email-detail-headers strong,
+      .email-detail-attachments a {
         color: #555;
       }
 
@@ -153,6 +190,7 @@
               to <%= Bamboo.SentEmailViewerPlug.Helper.email_addresses(email) %>
             </span>
             <span class="email-summary-body-excerpt">
+              <%= if Enum.count(email.attachments) > 0 do %><span class="email-attachment-icon"></span><% end %>
               <%= Bamboo.SentEmailViewerPlug.Helper.format_text_body(email.text_body) %>
             </span>
           </a>
@@ -172,6 +210,21 @@
               </div>
             <% end %>
           </span>
+          <% attachment_count = Enum.count(@selected_email.attachments) %>
+          <%= if  attachment_count > 0 do %>
+            <span class="email-detail-attachments">
+              <span class="email-detail-attachments-icon-container"><span class="email-attachment-icon"></span></span>
+              <ul>
+              <%= for index <- 0..attachment_count - 1 do %>
+                <%
+                  attachment = Enum.at(@selected_email.attachments, index)
+                  href = "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/attachments/#{index}"
+                %>
+                <li><a href="<%= href %>"><%= attachment.filename %></a></li>
+              <% end %>
+              </ul>
+            </span>
+          <% end %>
         </section>
 
         <section class="email-detail-bodies-container">

--- a/lib/mix/start_sent_email_viewer_task.ex
+++ b/lib/mix/start_sent_email_viewer_task.ex
@@ -35,12 +35,31 @@ defmodule Mix.Tasks.Bamboo.StartSentEmailViewer do
         Me and <em>html tag</em>
         """
       )
+      |> add_attachments(index)
       |> Bamboo.Mailer.normalize_addresses()
       |> Bamboo.SentEmail.push()
     end
 
     IO.puts("Running sent email viewer on port 4003")
     no_halt()
+  end
+
+  defp add_attachments(email, count) do
+    # First attachment will be an image, others will be docx files.
+    Enum.reduce(count..0, email, fn
+      0, email ->
+        email
+
+      1, email ->
+        path = Path.join(__DIR__, "../../logo/logo.png")
+        label = "bamboo-logo"
+        Bamboo.Email.put_attachment(email, path, filename: "#{label}.png")
+
+      index, email ->
+        path = Path.join(__DIR__, "../../test/support/attachment.docx")
+        label = "attachment-#{index}"
+        Bamboo.Email.put_attachment(email, path, filename: "#{label}.docx")
+    end)
   end
 
   defp no_halt do

--- a/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
+++ b/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
@@ -3,6 +3,7 @@ defmodule Bamboo.SentEmailViewerPlugTest do
   use Plug.Test
   import Bamboo.Factory
   alias Bamboo.SentEmail
+  alias Plug.HTML
 
   defmodule AppRouter do
     use Plug.Router
@@ -152,7 +153,9 @@ defmodule Bamboo.SentEmailViewerPlugTest do
   end
 
   test "shows attachments if email has them" do
-    [attachment1, attachment2] = attachments = [build(:attachment), build(:attachment)]
+    [attachment1, attachment2] =
+      attachments = [build(:attachment), build(:attachment, filename: "<b>attach</b>.txt")]
+
     normalize_and_push(:email, attachments: attachments)
     conn = conn(:get, "/sent_emails/foo")
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,4 +16,10 @@ defmodule Bamboo.Factory do
       html_body: "<p>ohai!</p>"
     }
   end
+
+  def attachment_factory do
+    path = Path.join(__DIR__, "attachment.txt")
+    filename = sequence(:attachment, &"attachment-#{&1}.txt")
+    Bamboo.Attachment.new(path, filename: filename)
+  end
 end


### PR DESCRIPTION
Adds support for viewing attachments in `SentEmailViewerPlug`.

Can be tested manually by running `mix bamboo.start_sent_email_viewer`.

Fixes #520 