### PR TITLE
Remove `@email_view_module` from Bamboo.Phoenix

### DIFF
--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -140,7 +140,6 @@ defmodule Bamboo.Phoenix do
     quote do
       import Bamboo.Email
       import Bamboo.Phoenix, except: [render: 3]
-      @email_view_module unquote(view_module)
 
       @doc """
       Render an Phoenix template and set the body on the email.
@@ -150,7 +149,7 @@ defmodule Bamboo.Phoenix do
       "welcome_email.text" or "welcome_email.html". Scroll to the top for more examples.
       """
       def render(email, template, assigns \\ []) do
-        Bamboo.Phoenix.render_email(@email_view_module, email, template, assigns)
+        Bamboo.Phoenix.render_email(unquote(view_module), email, template, assigns)
       end
     end
   end


### PR DESCRIPTION
What changed?
============

We remove the unnecessary setting of the `view` provided to `Bamboo.Phoenix` as `@email_view_module`. By setting it to a module attribute, we create a compile-time dependency, when we can simply pass it into the `render_email` function. It was originally set in [this commit](https://github.com/thoughtbot/bamboo/commit/9e08553595e8def2fa0cccb2662583cd21fd0f55#diff-dd737ef2fe5a0cd4fa37a32d32dc27c7d861e337fef92bae9e1c48cb8e1871ea).