### PR TITLE
fix: typespec in generated code

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -63,7 +63,7 @@ defmodule Bamboo.Mailer do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      @spec deliver_now(Bamboo.Email.t(), Enum.t()) :: Bamboo.Email.t() | {any, Bamboo.Email.t()}
+      @spec deliver_now(Bamboo.Email.t(), Enum.t()) :: Bamboo.Email.t() | {Bamboo.Email.t(), any}
       def deliver_now(email, opts \\ []) do
         {config, opts} = Keyword.split(opts, [:config])
         config = build_config(config)


### PR DESCRIPTION
Hi. This is a small typespec fix.

`@spec` for `deliver_now/2` when using `Bamboo.Mailer` defines tuple
for when we call it with `response: true` option.
However the slots in the tuple are misaligned from actual implementation,
causing dialyzer warning in our code.

Impl is:
```ex
      response = adapter.deliver(email, config)
      {email, response}
```
https://github.com/thoughtbot/bamboo/blob/8c5780319c5e2c936d04a2e1d9594be20a525c9b/lib/bamboo/mailer.ex#L149-L150