### PR TITLE
Add assign_many/2

### DIFF
--- a/lib/bamboo/phoenix.ex
+++ b/lib/bamboo/phoenix.ex
@@ -235,6 +235,13 @@ defmodule Bamboo.Phoenix do
     %{email | assigns: Map.put(assigns, key, value)}
   end
 
+  @doc """
+  Sets many assigns for the email at once. These weill be available when rendering the email
+  """
+  def assign_many(email, assigns) do
+    Enum.reduce(assigns, email, fn {key, value}, acc -> assign(acc, key, value) end)
+  end
+
   @doc false
   def render_email(view, email, template, assigns) do
     email

--- a/test/lib/bamboo/phoenix_test.exs
+++ b/test/lib/bamboo/phoenix_test.exs
@@ -53,6 +53,17 @@ defmodule Bamboo.PhoenixTest do
       new_email()
       |> render("template.foobar")
     end
+
+    def email_with_assigns do
+      new_email()
+      |> assign(:a, "a")
+      |> assign(:b, "b")
+      |> assign(:c, "c")
+    end
+
+    def email_with_many_assigns do
+      assign_many(new_email(), a: "a", b: "b", c: "c")
+    end
   end
 
   test "render/2 allows setting a custom layout" do
@@ -113,5 +124,14 @@ defmodule Bamboo.PhoenixTest do
     assert_raise RuntimeError, ~r/documentation only/, fn ->
       Bamboo.Phoenix.render(:foo, :foo, :foo)
     end
+  end
+
+  test "assign/3 will assign a variable for the email" do
+    assert %{assigns: %{a: "a", b: "b", c: "c"}} = Email.email_with_assigns()
+  end
+
+  test "assign_many/2 will assign many variables for the email" do
+    assert %{assigns: %{a: "a", b: "b", c: "c"}} =Email.email_with_many_assigns()
+    assert Email.email_with_assigns() == Email.email_with_many_assigns()
   end
 end

--- a/test/lib/bamboo/phoenix_test.exs
+++ b/test/lib/bamboo/phoenix_test.exs
@@ -131,7 +131,7 @@ defmodule Bamboo.PhoenixTest do
   end
 
   test "assign_many/2 will assign many variables for the email" do
-    assert %{assigns: %{a: "a", b: "b", c: "c"}} =Email.email_with_many_assigns()
+    assert %{assigns: %{a: "a", b: "b", c: "c"}} = Email.email_with_many_assigns()
     assert Email.email_with_assigns() == Email.email_with_many_assigns()
   end
 end


### PR DESCRIPTION
This will add the ability for a map or keyword to be used when making assigns for an email.

It also adds tests for `assign/3` and `assign_many/2`