### PR TITLE
Improve attachment support detection

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -213,7 +213,8 @@ defmodule Bamboo.Mailer do
   defp validate_attachment_support(%{attachments: []} = email, _adapter), do: email
 
   defp validate_attachment_support(email, adapter) do
-    if function_exported?(adapter, :supports_attachments?, 0) && adapter.supports_attachments? do
+    if Code.ensure_loaded?(adapter) && function_exported?(adapter, :supports_attachments?, 0) &&
+         adapter.supports_attachments? do
       email
     else
       raise "the #{adapter} does not support attachments yet."


### PR DESCRIPTION
This fixes a subtle bug which we encountered on one project in tests.

The problem is that `function_exported?` returns false if the module is not loaded (see [here](https://hexdocs.pm/elixir/Kernel.html?#function_exported?/3)). Consequently, if the beam is started in interactive mode (default when mix is used), Bamboo may incorrectly conclude that attachments are not supported.

This can lead to some strange behaviour in tests. For example, we had a test failing if executed in isolation, but sometimes the test would pass if all the tests are running. The test would always pass if the test adapter is recompiled while invoking `mix test`.

Note that the same issue can occur in prod if OTP release is not used.