### PR TITLE
Fix Email.address() typespec

### DIFF
--- a/lib/bamboo/email.ex
+++ b/lib/bamboo/email.ex
@@ -71,7 +71,7 @@ defmodule Bamboo.Email do
       end
   """
 
-  @type address :: String.t() | {String.t(), String.t()}
+  @type address :: {String.t(), String.t()}
   @type address_list :: nil | address | [address] | any
 
   @type t :: %__MODULE__{


### PR DESCRIPTION
What changed?
============

In https://github.com/thoughtbot/bamboo/pull/386, @evuez correctly pointed out that the `Bamboo.Email.address()` typespec shows `String.t() | {String.t(), String.t()}`. But no adapter actually supports the `String.t()` type.

Given that the code was introduced [before the typespecs](https://github.com/thoughtbot/bamboo/pull/150) (and thus we can treat the code as the source of truth when in doubt), and since `Bamboo.Email.get_address/1`'s explicit intent is to abstract the internal representation of email addresses in case Bamboo changes how it stores them:

> Gets just the email address from a normalized email address.
> Normalized email addresses are 2 item tuples {name, address}. This gets the address part of the tuple. Use this instead of calling elem(address, 1) so that if Bamboo changes how email addresses are represented your code will still work

  --   From [`get_address/1` docs](https://hexdocs.pm/bamboo/Bamboo.Email.html#get_address/1).

I think the correct change here is to remove the `String.t()` portion of the typespec rather than update the code to handle that typespec. In other words, I think we made a typo when introducing the typespec. So this PR would be merged instead of #386.