### PR TITLE
Update SendGrid Adapter to return ok/error tuple

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -47,19 +47,26 @@ defmodule Bamboo.SendGridAdapter do
 
   def deliver(email, config) do
     api_key = get_key(config)
-    body = email |> to_sendgrid_body(config) |> Bamboo.json_library().encode!()
-    url = [base_uri(), @send_message_path]
 
-    case :hackney.post(url, headers(api_key), body, AdapterHelper.hackney_opts(config)) do
-      {:ok, status, _headers, response} when status > 299 ->
-        filtered_params = body |> Bamboo.json_library().decode!() |> Map.put("key", "[FILTERED]")
-        raise_api_error(@service_name, response, filtered_params)
+    try do
+      body = email |> to_sendgrid_body(config) |> Bamboo.json_library().encode!()
+      url = [base_uri(), @send_message_path]
 
-      {:ok, status, headers, response} ->
-        %{status_code: status, headers: headers, body: response}
+      case :hackney.post(url, headers(api_key), body, AdapterHelper.hackney_opts(config)) do
+        {:ok, status, _headers, response} when status > 299 ->
+          filtered_params =
+            body |> Bamboo.json_library().decode!() |> Map.put("key", "[FILTERED]")
 
-      {:error, reason} ->
-        raise_api_error(inspect(reason))
+          {:error, build_api_error(@service_name, response, filtered_params)}
+
+        {:ok, status, headers, response} ->
+          {:ok, %{status_code: status, headers: headers, body: response}}
+
+        {:error, reason} ->
+          {:error, build_api_error(inspect(reason))}
+      end
+    catch
+      :throw, {:error, _} = error -> error
     end
   end
 
@@ -168,7 +175,7 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp build_personalization(_personalization) do
-    raise "Each personalization requires a 'to' field"
+    throw({:error, "Each personalization requires a 'to' field"})
   end
 
   defp map_put_if(map_out, map_in, key, mapper \\ & &1) do
@@ -381,7 +388,7 @@ defmodule Bamboo.SendGridAdapter do
   defp cast_time(unix_timestamp) when is_integer(unix_timestamp), do: unix_timestamp
 
   defp cast_time(_other) do
-    raise "expected 'send_at' time parameter to be a DateTime or unix timestamp"
+    throw({:error, "expected 'send_at' time parameter to be a DateTime or unix timestamp"})
   end
 
   defp cast_addresses(addresses, type) when is_list(addresses) do
@@ -410,7 +417,7 @@ defmodule Bamboo.SendGridAdapter do
     case {Map.get(address, :name, Map.get(address, "name")),
           Map.get(address, :email, Map.get(address, "email"))} do
       {_name, nil} ->
-        raise "Must specify at least an 'email' field in map #{inspect(address)}"
+        throw({:error, "Must specify at least an 'email' field in map #{inspect(address)}"})
 
       {nil, address} ->
         %{email: address}


### PR DESCRIPTION
Requires: https://github.com/thoughtbot/bamboo/pull/571

What changed?
==============

We update the `SendGridAdapter` to abide by the new Adapter behaviour. Adapters must now returns an `{:ok, email}` or `{:error, error}`.

Note on implementation with throw/catch
---------------------------------------

Building SendGrid's body requires a lot of deeply nested data manipulation. Some code that is deeply nested within branching logic raises errors.

Rather than returning an error tuple at a really low level and have to bubble up the error all the way until it's returned, we opted for a simpler approach: throwing and catching the errors.

We throw and catch `{:error, error}` when we used to `raise error`.

It's possible we could do something different in the future, like bubbling up the errors and returning them without having to resort to `throw` and `catch`, but right now we want to minimize the number of changes for these `raise`s deep in the call stack.

Raising (not returning) configuration errors
--------------------------------

While working on this, an important question came up. Should we raise or return an error because of a missing API key? Currently we raise.

I think it's okay to raise an error in that case because it's a configuration issue. It's not the same type of error that happens when you can't build an email, deliver it, or even get a response that isn't 200. That error is a configuration issue and so the sooner we notify the user of Bamboo, the better.

We can also think about it this way: we want to return an ok/error tuple because we people want to handle email building or delivery issues. Having an API key missing isn't that kind of issue. It means the library is configured incorrectly, so it seems good to raise an error.