### PR TITLE
Update Mailgun.deliver to return ok/error tuples

### DIFF
--- a/lib/bamboo/adapters/mailgun_adapter.ex
+++ b/lib/bamboo/adapters/mailgun_adapter.ex
@@ -104,13 +104,13 @@ defmodule Bamboo.MailgunAdapter do
          ) do
       {:ok, status, _headers, response} when status > 299 ->
         body = decode_body(body)
-        raise_api_error(@service_name, response, body)
+        {:error, build_api_error(@service_name, response, body)}
 
       {:ok, status, headers, response} ->
-        %{status_code: status, headers: headers, body: response}
+        {:ok, %{status_code: status, headers: headers, body: response}}
 
       {:error, reason} ->
-        raise_api_error(inspect(reason))
+        {:error, build_api_error(inspect(reason))}
     end
   end
 


### PR DESCRIPTION
Requires: https://github.com/thoughtbot/bamboo/pull/571

What changed?
==============

Updates Mailgin.deliver function to return ok/error tuples to abide by the new api.

Note on raising configuration errors
-----------------------------------

We do not change the raising of errors when they deal with configuration options. Those errors are categorically different. We want to return ok/error tuples when there's an error building/delivering email. If a user of Bamboo is missing a configuration variable, it seems important to raise an error.