### PR TITLE
Update Mandrill to return ok/error tuples

### DIFF
--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -41,13 +41,13 @@ defmodule Bamboo.MandrillAdapter do
         filtered_params =
           params |> Bamboo.json_library().decode!() |> Map.put("key", "[FILTERED]")
 
-        raise_api_error(@service_name, response, filtered_params)
+        {:error, build_api_error(@service_name, response, filtered_params)}
 
       {:ok, status, headers, response} ->
-        %{status_code: status, headers: headers, body: response}
+        {:ok, %{status_code: status, headers: headers, body: response}}
 
       {:error, reason} ->
-        raise_api_error(inspect(reason))
+        {:error, build_api_error(inspect(reason))}
     end
   end
 


### PR DESCRIPTION
Requires: https://github.com/thoughtbot/bamboo/pull/571

What changed?
============

Update MandrillAdapter to return an ok/error tuple to abide by the new behaviour api.

Note on configuration errors
--------------------------

We no longer raise api errors, but we do raise configuration errors. Since configuration errors do not fall under the category of email building/delivery errors, it seems fine that we raise those errors.