### PR TITLE
Update min version of hackney to 1.15.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Bamboo.Mixfile do
       {:excoveralls, "~> 0.13", only: :test},
       {:floki, "~> 0.29", only: :test},
       {:ex_doc, "~> 0.23", only: :dev},
-      {:hackney, ">= 1.13.0"},
+      {:hackney, ">= 1.15.2"},
       {:jason, "~> 1.0", optional: true}
     ]
   end


### PR DESCRIPTION
Closes : https://github.com/thoughtbot/bamboo/issues/512

There's an issue with older versions of hackney that results in failed HTTPS requests with this error:

```
{:error, {:option, :server_only, :honor_cipher_order}}
```

We bump the minimum hackney version to 1.15.2