### PR TITLE
Introduce Bamboo.Template and Bamboo.View

### DIFF
--- a/lib/bamboo/template.ex
+++ b/lib/bamboo/template.ex
@@ -124,7 +124,7 @@ defmodule Bamboo.Template do
 
       # lib/my_app/email/views/layout_view.ex
       defmodule MyApp.Email.LayoutView do
-        use Bamboo.View, path: "/lib/my_app/email/templates/layout"
+        use Bamboo.View, path: "lib/my_app/email/templates/layout"
       end
 
       # lib/my_app/email/templates/layout/email.html.eex
@@ -136,7 +136,7 @@ defmodule Bamboo.Template do
 
       # lib/my_app/email/views/account_view.ex
       defmodule MyApp.Email.AccountView do
-        use Bamboo.View, path: "/lib/my_app/email/templates/account"
+        use Bamboo.View, path: "lib/my_app/email/templates/account"
       end
 
       # lib/my_app/email/templates/account/welcome_email.html.eex

--- a/lib/bamboo/template.ex
+++ b/lib/bamboo/template.ex
@@ -1,0 +1,271 @@
+defmodule Bamboo.Template do
+  @moduledoc """
+  Render emails with layouts, view modules, and templates.
+
+  This module allows rendering emails with layouts and views. Pass an
+  atom (e.g. `:welcome_email`) as the template name to render both HTML and
+  plain text emails. Use a string if you only want to render one type, e.g.
+  `"welcome_email.text"` or `"welcome_email.html"`.
+
+  ## Examples
+
+  _Set the text and HTML layout for an email._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email do
+          new_email()
+          |> put_text_layout({MyApp.Email.LayoutView, "email.text"})
+          |> put_html_layout({MyApp.Email.LayoutView, "email.html"})
+          |> render(:welcome) # Pass atom to render html AND plain text templates
+        end
+      end
+
+  _Set both the text and HTML layout at the same time for an email._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email do
+          new_email()
+          |> put_layout({MyApp.Email.LayoutView, :email})
+          |> render(:welcome)
+        end
+      end
+
+  _Render both text and html emails without layouts._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email do
+          new_email()
+          |> render(:welcome)
+        end
+      end
+
+  _Make assigns available to a template._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email(user) do
+          new_email()
+          |> assign(:user, user)
+          |> render(:welcome)
+        end
+      end
+
+  _Make assigns available to a template during render call._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email(user) do
+          new_email()
+          |> put_html_layout({MyApp.Email.LayoutView, "email.html"})
+          |> render(:welcome, user: user)
+        end
+      end
+
+  _Render an email by passing the template string to render._
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def html_email do
+          new_email()
+          |> render("html_email.html")
+        end
+
+        def text_email do
+          new_email
+          |> render("text_email.text")
+        end
+      end
+
+  ## HTML Layout Example
+
+      # lib/my_app/email.ex
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.Email.AccountView
+
+        def welcome_email(person) do
+          base_email()
+          |> to(person)
+          |> subject("Welcome to MyApp")
+          |> assign(:person, person)
+          |> render(:welcome_email)
+        end
+
+        defp base_email do
+          new_email()
+          |> from("Rob Ot<robot@changelog.com>")
+          |> put_header("Reply-To", "editors@changelog.com")
+          # This will use the "email.html.eex" file as a layout when rendering html emails.
+          # Plain text emails will not use a layout unless you use `put_text_layout`
+          |> put_html_layout({MyApp.Email.LayoutView, "email.html"})
+        end
+      end
+
+      # lib/my_app/email/views/layout_view.ex
+      defmodule MyApp.Email.LayoutView do
+        use Bamboo.View, path: "/lib/my_app/email/templates/layout"
+      end
+
+      # lib/my_app/email/templates/layout/email.html.eex
+      <html>
+        <body>
+          <%= @inner_content %>
+        </body>
+      </html>
+
+      # lib/my_app/email/views/account_view.ex
+      defmodule MyApp.Email.AccountView do
+        use Bamboo.View, path: "/lib/my_app/email/templates/account"
+      end
+
+      # lib/my_app/email/templates/account/welcome_email.html.eex
+      # This will be rendered within a layout because `put_html_layout` was used.
+      <p>Welcome <%= @person.name %></p>
+
+      # lib/my_app/email/templates/account/welcome_email.text.eex
+      # This will not be rendered within a layout because `put_text_layout` was not used.
+      Welcome <%= @person.name %>
+  """
+
+  import Bamboo.Email, only: [put_private: 3]
+
+  defmacro __using__(view: view_module) do
+    quote do
+      import Bamboo.Email
+      import Bamboo.Template, except: [render: 3]
+
+      def render(email, template, assigns \\ []) do
+        Bamboo.View.render_email(unquote(view_module), email, template, assigns)
+      end
+    end
+  end
+
+  defmacro __using__(opts) do
+    raise ArgumentError, """
+    expected Bamboo.Template to have a view set, instead got: #{inspect(opts)}.
+
+    Please set a view e.g. use Bamboo.Template, view: MyEmailView
+    """
+  end
+
+  @doc """
+  Render a template and set the body on the email.
+
+  Pass an atom as the template name to render HTML *and* plain text emails,
+  e.g. `:welcome_email`. Use a string if you only want to render one type, e.g.
+  `"welcome_email.text"` or `"welcome_email.html"`.
+
+  You can also optionally pass assigns.
+
+  ## Example
+
+      # renders both HTML and text emails
+      new_email()
+      |> render(:template_name)
+
+      # renders HTML template
+      new_email()
+      |> render("template_name.html")
+
+      # renders text template
+      new_email()
+      |> render("template_name.text")
+
+      # renders with assigns
+      new_email()
+      |> render(:template_name, user: user)
+  """
+  def render(_email, _template_name, _assigns) do
+    raise "function implemented for documentation only, please call: `use Bamboo.Template`"
+  end
+
+  @doc """
+  Sets an assign for the email. These will be available when rendering the email
+
+  ## Example
+
+      new_email()
+      # assigns user to be accessed as `@user` in template
+      |> assign(:user, user)
+      |> render(:template_name)
+  """
+  def assign(%{assigns: assigns} = email, key, value) do
+    %{email | assigns: Map.put(assigns, key, value)}
+  end
+
+  @doc """
+  Sets the layout when rendering HTML templates.
+
+  ## Example
+
+      def html_email_layout do
+        new_email
+        # Will use the email.html template of MyApp.LayoutView when rendering html emails
+        |> put_html_layout({MyApp.LayoutView, "email.html"})
+      end
+  """
+  def put_html_layout(email, layout) do
+    email |> put_private(:html_layout, layout)
+  end
+
+  @doc """
+  Sets the layout when rendering plain text templates.
+
+  ## Example
+
+      def text_email_layout do
+        new_email
+        # Will use the email.text template of MyApp.LayoutView when rendering text emails
+        |> put_text_layout({MyApp.LayoutView, "email.text"})
+      end
+  """
+  def put_text_layout(email, layout) do
+    email |> put_private(:text_layout, layout)
+  end
+
+  @doc """
+  Sets the layout for rendering plain text and HTML templates.
+
+  ## Example
+
+      def text_and_html_email_layout do
+        new_email
+        # Will use email.html and email.text templates of MyApp.LayoutView
+        # when rendering HTML and text emails
+        |> put_layout({MyAppWeb.LayoutView, :email})
+      end
+  """
+  def put_layout(email, {layout, template}) do
+    email
+    |> put_text_layout({layout, to_string(template) <> ".text"})
+    |> put_html_layout({layout, to_string(template) <> ".html"})
+  end
+
+  @doc """
+  Overrides the view for rendering templates
+
+  ## Example
+
+      defmodule MyApp.Email do
+        use Bamboo.Template, view: MyApp.EmailView
+
+        def different_view_template do
+          new_email
+          # Will use welcome.html template of MyApp.AccountView
+          |> put_view(MyApp.AccountView)
+          |> render("welcome.html")
+        end
+      end
+  """
+  def put_view(email, view) do
+    email |> put_private(:view_module, view)
+  end
+end

--- a/lib/bamboo/view.ex
+++ b/lib/bamboo/view.ex
@@ -7,7 +7,7 @@ defmodule Bamboo.View do
   ## Example
 
       defmodule MyApp.EmailView do
-        use Bamboo.View, path: "/lib/my_app/email/templates"
+        use Bamboo.View, path: "lib/my_app/email/templates"
 
         def app_title do
           "My Super App"
@@ -52,7 +52,7 @@ defmodule Bamboo.View do
     raise ArgumentError, """
     expected Bamboo.View to have a path set, instead got: #{inspect(opts)}.
 
-    Please set a path where this view's template are defined e.g. use Bamboo.View, path: "/lib/my_app/email/templates/account"
+    Please set a path where this view's template are defined e.g. use Bamboo.View, path: "lib/my_app/email/templates/account"
     """
   end
 

--- a/lib/bamboo/view.ex
+++ b/lib/bamboo/view.ex
@@ -101,7 +101,8 @@ defmodule Bamboo.View do
   end
 
   defp merge_assigns(%{assigns: email_assigns} = email, assigns) do
-    Map.put(email, :assigns, Map.merge(email_assigns, Enum.into(assigns, %{}))
+    assigns = Map.merge(email_assigns, Enum.into(assigns, %{}))
+    Map.put(email, :assigns, assigns)
   end
 
   defp render(email, template) when is_atom(template) do
@@ -159,8 +160,7 @@ defmodule Bamboo.View do
     module = email.private.view_module
     contents = module.render_template(template, email.assigns)
 
-    assigns =
-      Map.put(email.assigns, :inner_content, contents)
+    assigns = Map.put(email.assigns, :inner_content, contents)
 
     layout_view.render_template(layout_template, assigns)
   end

--- a/lib/bamboo/view.ex
+++ b/lib/bamboo/view.ex
@@ -101,8 +101,7 @@ defmodule Bamboo.View do
   end
 
   defp merge_assigns(%{assigns: email_assigns} = email, assigns) do
-    assigns = email_assigns |> Map.merge(Enum.into(assigns, %{}))
-    email |> Map.put(:assigns, assigns)
+    Map.put(email, :assigns, Map.merge(email_assigns, Enum.into(assigns, %{}))
   end
 
   defp render(email, template) when is_atom(template) do
@@ -124,10 +123,10 @@ defmodule Bamboo.View do
   defp render_text_or_html_email(email, template) do
     cond do
       String.ends_with?(template, ".html") ->
-        email |> Map.put(:html_body, render_html(email, template))
+        Map.put(email, :html_body, render_html(email, template))
 
       String.ends_with?(template, ".text") ->
-        email |> Map.put(:text_body, render_text(email, template))
+        Map.put(email, :text_body, render_text(email, template))
 
       true ->
         raise ArgumentError, """
@@ -161,8 +160,7 @@ defmodule Bamboo.View do
     contents = module.render_template(template, email.assigns)
 
     assigns =
-      email.assigns
-      |> Map.put(:inner_content, contents)
+      Map.put(email.assigns, :inner_content, contents)
 
     layout_view.render_template(layout_template, assigns)
   end

--- a/lib/bamboo/view.ex
+++ b/lib/bamboo/view.ex
@@ -83,33 +83,11 @@ defmodule Bamboo.View do
   end
 
   @doc false
-  def render_email(view, email, template, assigns) do
-    email
-    |> put_defaults(view)
-    |> merge_assigns(assigns)
-    |> render(template)
-  end
-
-  defp put_defaults(%{private: private} = email, view_module) do
-    private =
-      private
-      |> Map.put_new(:html_layout, false)
-      |> Map.put_new(:text_layout, false)
-      |> Map.put_new(:view_module, view_module)
-
-    %{email | private: private}
-  end
-
-  defp merge_assigns(%{assigns: email_assigns} = email, assigns) do
-    assigns = Map.merge(email_assigns, Enum.into(assigns, %{}))
-    Map.put(email, :assigns, assigns)
-  end
-
-  defp render(email, template) when is_atom(template) do
+  def render(email, template) when is_atom(template) do
     render_html_and_text_emails(email, template)
   end
 
-  defp render(email, template) do
+  def render(email, template) do
     render_text_or_html_email(email, template)
   end
 

--- a/lib/bamboo/view.ex
+++ b/lib/bamboo/view.ex
@@ -1,0 +1,201 @@
+defmodule Bamboo.View do
+  @moduledoc """
+  Compiles and renders templates defined in a given path.
+
+  Functions defined in the view are available to use in its templates.
+
+  ## Example
+
+      defmodule MyApp.EmailView do
+        use Bamboo.View, path: "/lib/my_app/email/templates"
+
+        def app_title do
+          "My Super App"
+        end
+      end
+
+      # lib/my_app/email_templates/welcome.html
+      <h1>Welcome to <%= app_title() %></h1>
+  """
+
+  defmodule UndefinedTemplateError do
+    @moduledoc """
+    Exception raised when a template cannot be found.
+    """
+    defexception [:module, :template, :available]
+
+    def message(exception) do
+      ~s"""
+      Could not render #{inspect(exception.template)} for #{inspect(exception.module)}
+
+      #{available_templates(exception.available)}
+      """
+    end
+
+    defp available_templates([]), do: "No templates were compiled for this module."
+
+    defp available_templates(available) do
+      "The following templates were compiled:\n\n" <>
+        Enum.map_join(available, "\n", &"* #{&1}") <>
+        "\n"
+    end
+  end
+
+  defmacro __using__(path: path) do
+    quote do
+      @templates_path unquote(path)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __using__(opts) do
+    raise ArgumentError, """
+    expected Bamboo.View to have a path set, instead got: #{inspect(opts)}.
+
+    Please set a path where this view's template are defined e.g. use Bamboo.View, path: "/lib/my_app/email/templates/account"
+    """
+  end
+
+  defmacro __before_compile__(env) do
+    templates_path = Module.get_attribute(env.module, :templates_path)
+
+    results =
+      templates_path
+      |> templates_to_compile()
+      |> Enum.map(&template_and_name/1)
+      |> Enum.map(fn {template, name} ->
+        {name, compile(template, name)}
+      end)
+
+    template_names = Enum.map(results, &elem(&1, 0))
+    render_functions = Enum.map(results, &elem(&1, 1))
+
+    quote do
+      unquote(render_functions)
+
+      def render_template(template, _assigns) do
+        raise UndefinedTemplateError,
+          module: __MODULE__,
+          template: template,
+          available: unquote(template_names)
+      end
+    end
+  end
+
+  @doc false
+  def render_email(view, email, template, assigns) do
+    email
+    |> put_defaults(view)
+    |> merge_assigns(assigns)
+    |> render(template)
+  end
+
+  defp put_defaults(%{private: private} = email, view_module) do
+    private =
+      private
+      |> Map.put_new(:html_layout, false)
+      |> Map.put_new(:text_layout, false)
+      |> Map.put_new(:view_module, view_module)
+
+    %{email | private: private}
+  end
+
+  defp merge_assigns(%{assigns: email_assigns} = email, assigns) do
+    assigns = email_assigns |> Map.merge(Enum.into(assigns, %{}))
+    email |> Map.put(:assigns, assigns)
+  end
+
+  defp render(email, template) when is_atom(template) do
+    render_html_and_text_emails(email, template)
+  end
+
+  defp render(email, template) do
+    render_text_or_html_email(email, template)
+  end
+
+  defp render_html_and_text_emails(email, template) do
+    view_template = Atom.to_string(template)
+
+    email
+    |> Map.put(:html_body, render_html(email, view_template <> ".html"))
+    |> Map.put(:text_body, render_text(email, view_template <> ".text"))
+  end
+
+  defp render_text_or_html_email(email, template) do
+    cond do
+      String.ends_with?(template, ".html") ->
+        email |> Map.put(:html_body, render_html(email, template))
+
+      String.ends_with?(template, ".text") ->
+        email |> Map.put(:text_body, render_text(email, template))
+
+      true ->
+        raise ArgumentError, """
+        Template name must end in either ".html" or ".text". Template name was #{
+          inspect(template)
+        }
+
+        If you would like to render both and html and text template,
+        use an atom without an extension instead.
+        """
+    end
+  end
+
+  defp render_html(email, template) do
+    layout = email.private.html_layout
+    render_within_layout(layout, email, template)
+  end
+
+  defp render_text(email, template) do
+    layout = email.private.text_layout
+    render_within_layout(layout, email, template)
+  end
+
+  defp render_within_layout(_layout = false, email, template) do
+    module = email.private.view_module
+    module.render_template(template, email.assigns)
+  end
+
+  defp render_within_layout({layout_view, layout_template}, email, template) do
+    module = email.private.view_module
+    contents = module.render_template(template, email.assigns)
+
+    assigns =
+      email.assigns
+      |> Map.put(:inner_content, contents)
+
+    layout_view.render_template(layout_template, assigns)
+  end
+
+  defp templates_to_compile(directory) do
+    Path.wildcard(directory <> "/*.eex")
+  end
+
+  defp template_and_name(template) do
+    name =
+      template
+      |> Path.basename()
+      |> Path.rootname(".eex")
+
+    {template, name}
+  end
+
+  defp compile(template, name) do
+    quoted_contents = EEx.compile_file(template, line: 1, engine: EEx.SmartEngine)
+    function_name = String.to_atom(name)
+
+    quote do
+      @file unquote(name)
+      @external_resource unquote(template)
+
+      defp unquote(function_name)(var!(assigns)) do
+        _ = var!(assigns)
+        unquote(quoted_contents)
+      end
+
+      def render_template(unquote(name), assigns) do
+        unquote(function_name)(assigns)
+      end
+    end
+  end
+end

--- a/test/lib/bamboo/template_test.exs
+++ b/test/lib/bamboo/template_test.exs
@@ -1,5 +1,5 @@
 defmodule Bamboo.TemplateTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   defmodule LayoutView do
     use Bamboo.View, path: "test/support/templates/layout"

--- a/test/lib/bamboo/template_test.exs
+++ b/test/lib/bamboo/template_test.exs
@@ -17,6 +17,27 @@ defmodule Bamboo.TemplateTest do
     end
   end
 
+  defmodule EmailWithLayout do
+    use Bamboo.Template,
+      view: EmailView,
+      html_layout: {LayoutView, "app.html"},
+      text_layout: {LayoutView, "app.text"}
+
+    def text_and_html_email do
+      new_email()
+      |> render(:text_and_html_email)
+    end
+  end
+
+  defmodule EmailNoView do
+    use Bamboo.Template
+
+    def no_view do
+      new_email()
+      |> render(:text_and_html_email)
+    end
+  end
+
   defmodule Email do
     use Bamboo.Template, view: EmailView
 
@@ -76,6 +97,15 @@ defmodule Bamboo.TemplateTest do
 
   test "render/2 allows setting a custom layout" do
     email = Email.text_and_html_email_with_layout()
+
+    assert email.html_body =~ "HTML layout"
+    assert email.html_body =~ "HTML body"
+    assert email.text_body =~ "TEXT layout"
+    assert email.text_body =~ "TEXT body"
+  end
+
+  test "render/2 uses default layout if given one" do
+    email = EmailWithLayout.text_and_html_email()
 
     assert email.html_body =~ "HTML layout"
     assert email.html_body =~ "HTML body"
@@ -145,6 +175,12 @@ defmodule Bamboo.TemplateTest do
   test "render raises if called directly" do
     assert_raise RuntimeError, ~r/documentation only/, fn ->
       Bamboo.Template.render(:foo, :foo, :foo)
+    end
+  end
+
+  test "render/2 raises an error if no view is specified" do
+    assert_raise ArgumentError, ~r/have a view set/, fn ->
+      EmailNoView.no_view()
     end
   end
 end

--- a/test/lib/bamboo/template_test.exs
+++ b/test/lib/bamboo/template_test.exs
@@ -1,24 +1,28 @@
-defmodule Bamboo.PhoenixTest do
+defmodule Bamboo.TemplateTest do
   use ExUnit.Case
 
-  defmodule PhoenixLayoutView do
-    use Phoenix.View, root: "test/support/templates", namespace: Bamboo.PhoenixLayoutView
+  defmodule LayoutView do
+    use Bamboo.View, path: "test/support/templates/layout"
+  end
+
+  defmodule AdminView do
+    use Bamboo.View, path: "test/support/templates/admin_email"
   end
 
   defmodule EmailView do
-    use Phoenix.View, root: "test/support/templates", namespace: Bamboo.EmailView
+    use Bamboo.View, path: "test/support/templates/email"
 
     def function_in_view do
-      "function used in Bamboo.TemplateTest but needed because template is compiled"
+      "Text in view"
     end
   end
 
   defmodule Email do
-    use Bamboo.Phoenix, view: EmailView
+    use Bamboo.Template, view: EmailView
 
     def text_and_html_email_with_layout do
       new_email()
-      |> put_layout({PhoenixLayoutView, :app})
+      |> put_layout({LayoutView, :app})
       |> render(:text_and_html_email)
     end
 
@@ -46,6 +50,17 @@ defmodule Bamboo.PhoenixTest do
     def text_email do
       new_email()
       |> render("text_email.text")
+    end
+
+    def text_and_html_calling_view_function_email do
+      new_email()
+      |> render(:text_and_html_calling_view_function_email)
+    end
+
+    def text_and_html_from_different_view do
+      new_email()
+      |> put_view(AdminView)
+      |> render(:text_and_html_from_different_view)
     end
 
     def no_template do
@@ -101,8 +116,22 @@ defmodule Bamboo.PhoenixTest do
     assert email.text_body =~ "TEXT body"
   end
 
+  test "render/2 can use functions in the view itself" do
+    email = Email.text_and_html_calling_view_function_email()
+
+    assert email.html_body =~ "Text in view"
+    assert email.text_body =~ "Text in view"
+  end
+
+  test "render/2 allows overriding view with put_view" do
+    email = Email.text_and_html_from_different_view()
+
+    assert email.html_body =~ "HTML from different view"
+    assert email.text_body =~ "TEXT from different view"
+  end
+
   test "render/2 raises if template doesn't exist" do
-    assert_raise Phoenix.Template.UndefinedError, fn ->
+    assert_raise Bamboo.View.UndefinedTemplateError, ~r/Could not render/, fn ->
       Email.no_template()
     end
   end
@@ -115,7 +144,7 @@ defmodule Bamboo.PhoenixTest do
 
   test "render raises if called directly" do
     assert_raise RuntimeError, ~r/documentation only/, fn ->
-      Bamboo.Phoenix.render(:foo, :foo, :foo)
+      Bamboo.Template.render(:foo, :foo, :foo)
     end
   end
 end

--- a/test/support/templates/admin_email/text_and_html_from_different_view.html.eex
+++ b/test/support/templates/admin_email/text_and_html_from_different_view.html.eex
@@ -1,0 +1,1 @@
+HTML from different view

--- a/test/support/templates/admin_email/text_and_html_from_different_view.text.eex
+++ b/test/support/templates/admin_email/text_and_html_from_different_view.text.eex
@@ -1,0 +1,1 @@
+TEXT from different view

--- a/test/support/templates/email/text_and_html_calling_view_function_email.html.eex
+++ b/test/support/templates/email/text_and_html_calling_view_function_email.html.eex
@@ -1,0 +1,1 @@
+<%= function_in_view() %>

--- a/test/support/templates/email/text_and_html_calling_view_function_email.text.eex
+++ b/test/support/templates/email/text_and_html_calling_view_function_email.text.eex
@@ -1,0 +1,1 @@
+<%= function_in_view() %>

--- a/test/support/templates/layout/app.html.eex
+++ b/test/support/templates/layout/app.html.eex
@@ -1,2 +1,2 @@
 HTML layout
-<%= render @view_module, @view_template, assigns %>
+<%= @inner_content %>

--- a/test/support/templates/layout/app.text.eex
+++ b/test/support/templates/layout/app.text.eex
@@ -1,2 +1,2 @@
 TEXT layout
-<%= render @view_module, @view_template, assigns %>
+<%= @inner_content %>

--- a/test/support/templates/phoenix_layout/app.html.eex
+++ b/test/support/templates/phoenix_layout/app.html.eex
@@ -1,0 +1,2 @@
+HTML layout
+<%= render @view_module, @view_template, assigns %>

--- a/test/support/templates/phoenix_layout/app.text.eex
+++ b/test/support/templates/phoenix_layout/app.text.eex
@@ -1,0 +1,2 @@
+TEXT layout
+<%= render @view_module, @view_template, assigns %>


### PR DESCRIPTION
Closes: https://github.com/thoughtbot/bamboo/issues/541, https://github.com/thoughtbot/bamboo/issues/323

What changed?
=============

We introduce two new modules `Bamboo.Template` and `Bamboo.View` so that Bamboo users can use HTML and text templates without having to rely on Phoenix (not all Bamboo users use Phoenix).

The implementation is based heavily on Phoenix's Template and View modules. So a huge thanks to them for all the hard work.

Example usage:

```elixir
defmodule MyApp.EmailView do
  use Bamboo.View, path: "/path/to/this/view/templates"
end

defmodule MyApp.Email do
  use Bamboo.Template, view: MyApp.EmailView

  def welcome_email do
    new_email()
    |> put_layout({MyApp.EmailLayout, :email})
    |> render(:welcome_email)
  end
end
```

The goal is for `Bamboo.Template` to coexist with `Bamboo.Phoenix`, and `Bamboo.Phoenix` can be moved to a separate package in the future.

Difference from Phoenix Views
-----------------------------

When using `Bamboo.View` we have to specify the full path where the templates for that view will live (instead of the root path as is done in `Phoenix.View`).

We could do fancier things where we auto detect the location based on the module name, but that seems a little magical and perhaps unnecessary for now. We can always add that if we need it. For now, we can specify a view, and set the path for its templates.

Difference from Bamboo.Phoenix
-----------------------------

Unlike `Bamboo.Phoenix`, `Bamboo.Template` allows for overriding the view with `put_view/2` for cases when we don't have to rely on the view defined in `use Bamboo.Template, view: EmailView`.

Note on alternate implementation
--------------------------------

The first pass at doing this used`EEx.function_from_file` instead `EEx.compile_file` and unquoting the compiled file as we define the function. But I ran into issues with the `function_from_file` approach because assigns needed to be keyword lists instead of maps. At that point, I looked at the approach `Phoenix.Template` uses, and decided to follow their approach of using `EEx.compile_file`.

See [Phoenix.Template's approach](https://github.com/phoenixframework/phoenix/blob/e05af0ad5527c9a192de122f3e43d7ed4c7a4c9f/lib/phoenix/template.ex#L346-L365)

Note on updated Bamboo.Phoenix tests
------------------------------------

Even though there were no changes to `Bamboo.Phoenix`, there were a couple of changes to `bamboo/phoenix_test`. That happened because we tried to reuse as many as the test templates as possible.

We did separate a `PhoenixLayoutView` since the layouts render their contents differently. `Bamboo.Phoenix` uses a version of Phoenix that still uses `render @view_module, @view_template, assigns` in the layout. But `Bamboo.View` is using `@inner_content`, like more recent versions of Phoenix.

We also have to include the `function_in_view/0` function in `bamboo/phoenix_test`'s `EmailView` since the view compiles a new template that calls that function.