### PR TITLE
Import ExUnit.Assertions in Bamboo.Test.assert_delivered_email_matches

### DIFF
--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -183,7 +183,7 @@ defmodule Bamboo.Test do
   """
   defmacro assert_delivered_email_matches(email_pattern) do
     quote do
-      require ExUnit.Assertions
+      import ExUnit.Assertions
       ExUnit.Assertions.assert_receive({:delivered_email, unquote(email_pattern)})
     end
   end


### PR DESCRIPTION
This fixes what is a probably very rare use-case: I'm using macros from `Bamboo.Test` in helper functions that provide a more convenient API for testing emails in my codebase, i.e. I'm basically wrapping `Bamboo.Test` in my own module. 

I noticed that if I use `assert_delivered_email_matches` in my module then it doesn't compile because it complains about `flunk` from `ExUnit.Assertions` not being available. I thought that it could be fixed by importing `ExUnit.Assertions` in this macro like in the other macros instead of requiring it.