### PR TITLE
Collapsed email preview iframe bugfix

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -233,7 +233,10 @@
             <script>
             function adjustFrameHeight(iframe) {
               var contentWindow = iframe.contentWindow;
-              iframe.style.height = (contentWindow.outerHeight) + "px";
+              var height = (contentWindow.outerHeight)
+                ? contentWindow.outerHeight
+                : contentWindow.screen.availHeight;
+              iframe.style.height = height + "px";
             }
             </script>
             <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>


### PR DESCRIPTION
As part of the Wallaby feature test I've needed to read an email, but I could only get iframe element using `Wallaby.Query.css("iframe", visible: false)` because the height of the element is 0.

I've tried this in multiple versions of Chrome and chromedriver. Also, I've only been able to experience this in headless Chrome in macOS. I wasn't having this issue with Wallaby option `headless: false` nor on a CI instance running Ubuntu.

I figured this is not important enough that we should have test for this which adds chromedriver dependency, but I can add it if it's required.

Related to https://github.com/thoughtbot/bamboo/issues/350 and https://github.com/thoughtbot/bamboo/pull/351.