### PR TITLE
Remove deprecated code

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -352,16 +352,6 @@ defmodule Bamboo.Mailer do
     Formatter.format_email_address(record, %{type: type})
   end
 
-  @doc false
-  def parse_opts(mailer, opts) do
-    Logger.warn(
-      "#{__MODULE__}.parse_opts/2 has been deprecated. Use #{__MODULE__}.build_config/2"
-    )
-
-    otp_app = Keyword.fetch!(opts, :otp_app)
-    build_config(mailer, otp_app)
-  end
-
   def build_config(mailer, otp_app, optional_overrides \\ %{}) do
     otp_app
     |> Application.fetch_env!(mailer)

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -31,13 +31,4 @@ defmodule Bamboo.TaskSupervisorStrategy do
   def supervisor_name do
     Bamboo.TaskSupervisor
   end
-
-  @doc false
-  def child_spec do
-    raise """
-    Bamboo.TaskSupervisorStrategy is now automatically started by the :bamboo application.
-
-    Please remove the call to Bamboo.TaskSupervisorStrategy.child_spec
-    """
-  end
 end

--- a/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
+++ b/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
@@ -45,10 +45,4 @@ defmodule Bamboo.TaskSupervisorStrategyTest do
     assert %RuntimeError{message: "an error happened"} = elem(error, 0)
     refute_receive :delivered
   end
-
-  test "child_spec raises error about removal" do
-    assert_raise RuntimeError, ~r/Bamboo.TaskSupervisorStrategy.child_spec/, fn ->
-      Bamboo.TaskSupervisorStrategy.child_spec()
-    end
-  end
 end


### PR DESCRIPTION
What changed?
=============

We remove deprecated code. In particular, we remove:

1. `Bamboo.Mailer.parse_opts/2`. It's been deprecated since commit https://github.com/thoughtbot/bamboo/commit/584ec6369d23789a900b65fbe8d29793367c5cfb and people can use `build_config/2` instead.

2. `TaskSupervisorStrategy.child_spec/0`. That function raises an error to notify people that the supervisor is automatically started and there's no need for setting it up. That change was introduced in https://github.com/thoughtbot/bamboo/commit/28ca48a8f90a4ee578f1edc5d9eed086daf77e13 and removed from documentation. I think that error can now be removed.