### PR TITLE
Fix type spec of Mailer.deliver_later/1

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -80,7 +80,8 @@ defmodule Bamboo.Mailer do
         Bamboo.Mailer.deliver_now!(config.adapter, email, config, opts)
       end
 
-      @spec deliver_later(Bamboo.Email.t()) :: Bamboo.Email.t()
+      @spec deliver_later(Bamboo.Email.t()) ::
+              {:ok, Bamboo.Email.t()} | {:error, Exception.t() | String.t()}
       def deliver_later(email, opts \\ []) do
         config = build_config(opts)
         Bamboo.Mailer.deliver_later(config.adapter, email, config)


### PR DESCRIPTION
After updating to 2.0.0, my dialyzer fails with a message like this:

```
lib/my_app/mailer/mailgun.ex:17:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
MyApp.Mailer.Mailgun.BambooMailer.deliver_later/1

Success typing:
@spec deliver_later(_) ::
  {:error,
   <<_::64, _::size(8)>>
   | %{
       :__exception__ => true,
       :__struct__ => Bamboo.EmptyFromAddressError | Bamboo.NilRecipientsError,
       :message => <<_::64, _::size(8)>>
     }}
  | {:ok,
     %{
       :bcc => {binary(), binary()},
       :cc => {binary(), binary()},
       :from => {binary(), binary()},
       :to => {binary(), binary()},
       _ => _
     }}

________________________________________________________________________________
done (warnings were emitted)
```

This PR fixes that spec error.