### PR TITLE
Fix type spec & doc of Formatter.format_email_address/2 

### DIFF
--- a/lib/bamboo/formatter.ex
+++ b/lib/bamboo/formatter.ex
@@ -56,7 +56,7 @@ defprotocol Bamboo.Formatter do
   """
 
   @doc ~S"""
-  Receives data and opts and returns a string or a two item tuple `{name, address}`
+  Receives data and opts and returns a string, a two item tuple `{name, address}`, or a list of either.
 
   opts is a map with the key `:type` and a value of
   `:from`, `:to`, `:cc` or `:bcc`. You can pattern match on this to customize
@@ -65,7 +65,7 @@ defprotocol Bamboo.Formatter do
 
   @type opts :: %{optional(:type) => :from | :to | :cc | :bcc}
 
-  @spec format_email_address(any, opts) :: Bamboo.Email.address()
+  @spec format_email_address(any, opts) :: Bamboo.Email.address_list()
   def format_email_address(data, opts)
 end
 


### PR DESCRIPTION
`Formatter.format_email_address/2` can return an address or [list of addresses](https://github.com/thoughtbot/bamboo/blob/9e13937eb9a8f5d67c4c9c1d9009ae798f04d5c8/lib/bamboo/formatter.ex#L74). Both single address and list are accounted for in the [`address_list`](https://github.com/thoughtbot/bamboo/blob/4080bd67eb13347c57de50dc32fefaa473e6c423/lib/bamboo/email.ex#L75) type.