### PR TITLE
Fix LocalAdapter.deliver/2 return type

### DIFF
--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -33,7 +33,8 @@ defmodule Bamboo.LocalAdapter do
   @doc "Adds email to `Bamboo.SentEmail`, can automatically open it in new browser tab"
   def deliver(email, %{open_email_in_browser_url: open_email_in_browser_url}) do
     %{private: %{local_adapter_id: local_adapter_id}} = SentEmail.push(email)
-    open_url_in_browser("#{open_email_in_browser_url}/#{local_adapter_id}")
+
+    {:ok, open_url_in_browser("#{open_email_in_browser_url}/#{local_adapter_id}")}
   end
 
   def deliver(email, _config) do


### PR DESCRIPTION
Fixes issue #588 

Fix the `LocalAdapter.deliver/2` to return a `{:ok, result}` tuple when
the adapter is configured with the `open_email_in_browser_url` option.

This does not include a test as I could not come up with a way to test the local adapter with out it attempting a `System.cmd` call and trying to open a file/browser window while running the tests.

Any suggestions there would be appreciated.

I was looking at adding the test to the `Bamboo.Adapters.LocalAdapterTest` like the following:

```elixir
  test "sent emails has emails that were delivered synchronously" do
    email = new_email(subject: "This is my email")

    config = %{
      open_email_in_browser_url: ""
    }

    {:ok, _response} = email |> LocalAdapter.deliver(config)

    assert [%Bamboo.Email{subject: "This is my email"}] = SentEmail.all()
  end
```
The above results in a message being logged while running the tests: "The file $filename does not exist."