### PR TITLE
Fix bug in LocalAdapter with an open_email_in_browser_url config

### DIFF
--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -32,9 +32,10 @@ defmodule Bamboo.LocalAdapter do
 
   @doc "Adds email to `Bamboo.SentEmail`, can automatically open it in new browser tab"
   def deliver(email, %{open_email_in_browser_url: open_email_in_browser_url}) do
-    %{private: %{local_adapter_id: local_adapter_id}} = SentEmail.push(email)
-
-    {:ok, open_url_in_browser("#{open_email_in_browser_url}/#{local_adapter_id}")}
+    delivered_email = SentEmail.push(email)
+    %{private: %{local_adapter_id: local_adapter_id}} = delivered_email
+    open_url_in_browser("#{open_email_in_browser_url}/#{local_adapter_id}")
+    {:ok, delivered_email}
   end
 
   def deliver(email, _config) do
@@ -44,6 +45,8 @@ defmodule Bamboo.LocalAdapter do
   def handle_config(config), do: config
 
   def supports_attachments?, do: true
+
+  defp open_url_in_browser("test://" <> _), do: :opened
 
   defp open_url_in_browser(url) when is_binary(url) do
     case :os.type() do

--- a/test/lib/bamboo/adapters/local_adapter_test.exs
+++ b/test/lib/bamboo/adapters/local_adapter_test.exs
@@ -18,4 +18,11 @@ defmodule Bamboo.LocalAdapterTest do
 
     assert [%Bamboo.Email{subject: "This is my email"}] = SentEmail.all()
   end
+
+  test "using open_email_in_browser_url doesn't raise an error" do
+    email = new_email(subject: "This is my email")
+
+    assert {:ok, _response} =
+             email |> LocalAdapter.deliver(%{open_email_in_browser_url: "test://"})
+  end
 end


### PR DESCRIPTION
When LocalAdapter is used with an `open_email_in_browser_url` config, delivering emails throws an error https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/adapters/local_adapter.ex#L34-L37 returns a `{"", 0}` which doesn't match https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/mailer.ex#L206-L209