### PR TITLE
Adapter that replaces all recipients with a default list

### DIFF
--- a/lib/bamboo/adapters/recipient_replacer_adapter.ex
+++ b/lib/bamboo/adapters/recipient_replacer_adapter.ex
@@ -7,12 +7,15 @@ defmodule Bamboo.RecipientReplacerAdapter do
   with the provided list of addresses and set original values for `to`, `cc` and `bcc`
   in headers.
 
+  ### Doesn't support adapters without attachments_support
+
   ## Example config
 
       # Typically done in config/staging.exs
-      config :my_pp, MyAppMailer.
+      config :my_app, MyAppMailer.
         adapter: Bamboo.RecipientReplacerAdapter,
         inner_adapter: Bamboo.SendGridAdapter,
+        recipient_replacements: ["user-1@example.com", "user-2@example.com"],
         ...
 
       # Define a Mailer. Typically in lib/my_app/mailer.ex

--- a/lib/bamboo/adapters/recipient_replacer_adapter.ex
+++ b/lib/bamboo/adapters/recipient_replacer_adapter.ex
@@ -23,6 +23,8 @@ defmodule Bamboo.RecipientReplacerAdapter do
 
   import Bamboo.Email, only: [put_header: 3]
 
+  defmodule(AdapterNotSupportedError, do: defexception([:message]))
+
   @behaviour Bamboo.Adapter
 
   @doc false
@@ -32,6 +34,11 @@ defmodule Bamboo.RecipientReplacerAdapter do
     original_bcc = Map.get(email, :bcc, [])
 
     adapter = config.inner_adapter
+
+    if not adapter.supports_attachments?() do
+      raise AdapterNotSupportedError,
+            "RecipientReplacerAdapter supports only adapters that support attachments"
+    end
 
     recipients_list =
       config.recipient_replacements

--- a/lib/bamboo/adapters/recipient_replacer_adapter.ex
+++ b/lib/bamboo/adapters/recipient_replacer_adapter.ex
@@ -1,0 +1,71 @@
+defmodule Bamboo.RecipientReplacerAdapter do
+  @moduledoc """
+  Replaces to addresses with a provided recipients list.
+
+  It provides a wrapper for any other mailer adapter, usefull when working on releases
+  machine with real email address. It simply replaces `to` addresses
+  with the provided list of addresses and set original values for `to`, `cc` and `bcc`
+  in headers.
+
+  ## Example config
+
+      # Typically done in config/staging.exs
+      config :my_pp, MyAppMailer.
+        adapter: Bamboo.RecipientReplacerAdapter,
+        inner_adapter: Bamboo.SendGridAdapter,
+        ...
+
+      # Define a Mailer. Typically in lib/my_app/mailer.ex
+      defmodule MyApp.Mailer do
+        use Bamboo.Mailer, otp_app: :my_app
+      end
+  """
+
+  import Bamboo.Email, only: [put_header: 3]
+
+  @behaviour Bamboo.Adapter
+
+  @doc false
+  def deliver(email, config) do
+    original_to = Map.get(email, :to, [])
+    original_cc = Map.get(email, :cc, [])
+    original_bcc = Map.get(email, :bcc, [])
+
+    adapter = config.inner_adapter
+
+    recipients_list =
+      config.recipient_replacements
+      |> Enum.map(&{nil, &1})
+
+    email =
+      email
+      |> Map.put(:to, recipients_list)
+      |> Map.put(:cc, [])
+      |> Map.put(:bcc, [])
+      |> put_header("X-Real-To", convert_recipients_list(original_to))
+      |> put_header("X-Real-Cc", convert_recipients_list(original_cc))
+      |> put_header("X-Real-Bcc", convert_recipients_list(original_bcc))
+
+    adapter.deliver(email, config)
+  end
+
+  @doc false
+  def handle_config(config) do
+    adapter = config.inner_adapter
+
+    adapter.handle_config(config)
+  end
+
+  @doc false
+  def supports_attachments?, do: true
+
+  defp convert_recipients_list(recipients_list) do
+    Enum.map(recipients_list, fn {name, address} ->
+      case name do
+        nil -> address
+        name -> "<#{name}>#{address}"
+      end
+    end)
+    |> Enum.join(",")
+  end
+end

--- a/test/lib/bamboo/adapters/recipient_replacer_adapter_test.exs
+++ b/test/lib/bamboo/adapters/recipient_replacer_adapter_test.exs
@@ -20,7 +20,13 @@ defmodule Bamboo.RecipientReplacerAdapterTest do
     Application.put_env(:bamboo, __MODULE__.Mailer, config)
     Process.register(self(), :mailer_test)
     on_exit(fn -> Application.delete_env(:bamboo, __MODULE__.Mailer) end)
-    :ok
+
+    from = "sender@example.com"
+    receiver_to = ["receiver-to@example.com", "another-receiver-to@example.com"]
+    receiver_cc = "receiver-cc@example.com"
+    receiver_bcc = "receiver-bcc@example.com"
+    email = Email.new_email(to: receiver_to, from: from, cc: receiver_cc, bcc: receiver_bcc)
+    %{email: email}
   end
 
   defmodule GenericAdapter do
@@ -48,13 +54,7 @@ defmodule Bamboo.RecipientReplacerAdapterTest do
   defmodule(Mailer, do: use(Bamboo.Mailer, otp_app: :bamboo))
 
   @tag inner_adapter: GenericAdapter
-  test "replaces to addresses with configured recipients" do
-    from = "sender@example.com"
-    receiver_to = ["receiver-to@example.com", "another-receiver-to@example.com"]
-    receiver_cc = "receiver-cc@example.com"
-    receiver_bcc = "receiver-bcc@example.com"
-    email = Email.new_email(to: receiver_to, from: from, cc: receiver_cc, bcc: receiver_bcc)
-
+  test "replaces to addresses with configured recipients", %{email: email} do
     {:ok, _delivered_email} = Mailer.deliver_now(email)
 
     assert_received {:deliver, delivered_email, _}
@@ -71,13 +71,7 @@ defmodule Bamboo.RecipientReplacerAdapterTest do
   end
 
   @tag inner_adapter: NoAttachmentSupportAdapter
-  test "raises an exception if adapter doens't support attachments" do
-    from = "sender@example.com"
-    receiver_to = ["receiver-to@example.com", "another-receiver-to@example.com"]
-    receiver_cc = "receiver-cc@example.com"
-    receiver_bcc = "receiver-bcc@example.com"
-    email = Email.new_email(to: receiver_to, from: from, cc: receiver_cc, bcc: receiver_bcc)
-
+  test "raises an exception if adapter doens't support attachments", %{email: email} do
     assert_raise AdapterNotSupportedError,
                  "RecipientReplacerAdapter supports only adapters that support attachments",
                  fn ->

--- a/test/lib/bamboo/adapters/recipient_replacer_adapter_test.exs
+++ b/test/lib/bamboo/adapters/recipient_replacer_adapter_test.exs
@@ -1,0 +1,60 @@
+defmodule Bamboo.RecipientReplacerAdapterTest do
+  use ExUnit.Case
+
+  alias Bamboo.Email
+  alias Bamboo.RecipientReplacerAdapter
+
+  @mailer_config [
+    adapter: RecipientReplacerAdapter,
+    recipient_replacements: ["replaced@example.com"]
+  ]
+
+  setup context do
+    config =
+      Keyword.merge(@mailer_config, [inner_adapter: context[:inner_adapter]], fn
+        _key, default, nil -> default
+        _key, _default, override -> override
+      end)
+
+    Application.put_env(:bamboo, __MODULE__.Mailer, config)
+    Process.register(self(), :mailer_test)
+    on_exit(fn -> Application.delete_env(:bamboo, __MODULE__.Mailer) end)
+    :ok
+  end
+
+  defmodule GenericAdapter do
+    def deliver(email, config) do
+      send(:mailer_test, {:deliver, email, config})
+      {:ok, email}
+    end
+
+    def handle_config(config), do: config
+
+    def supports_attachments?, do: true
+  end
+
+  defmodule(Mailer, do: use(Bamboo.Mailer, otp_app: :bamboo))
+
+  @tag inner_adapter: GenericAdapter
+  test "replaces to addresses with configured recipients" do
+    from = "sender@example.com"
+    receiver_to = ["receiver-to@example.com", "another-receiver-to@example.com"]
+    receiver_cc = "receiver-cc@example.com"
+    receiver_bcc = "receiver-bcc@example.com"
+    email = Email.new_email(to: receiver_to, from: from, cc: receiver_cc, bcc: receiver_bcc)
+
+    {:ok, _delivered_email} = Mailer.deliver_now(email)
+
+    assert_received {:deliver, delivered_email, _}
+
+    assert [{nil, "replaced@example.com"}] = delivered_email.to
+    assert [] = delivered_email.cc
+    assert [] = delivered_email.bcc
+
+    assert %{
+             "X-Real-To" => "receiver-to@example.com,another-receiver-to@example.com",
+             "X-Real-Cc" => "receiver-cc@example.com",
+             "X-Real-Bcc" => "receiver-bcc@example.com"
+           } = delivered_email.headers
+  end
+end


### PR DESCRIPTION
As I proposed in #594, this PR add a new Adapter that is a wrapper around other adapters (i.e SendgridAdapter).

The idea is that on staging or releases environment, when someone send an email to any addresses, it replaces the to addresses with a default list and sets email headers with the original recipients in order to allow debugging before publishing on the production environment.