### PR TITLE
Introduce assign/2 to set many assigns

### DIFF
--- a/lib/bamboo/template.ex
+++ b/lib/bamboo/template.ex
@@ -204,7 +204,25 @@ defmodule Bamboo.Template do
   end
 
   @doc """
-  Sets an assign for the email. These will be available when rendering the email
+  Sets many assigns for an email. Accepts a map or a keyword list. See
+  `assign/3` for more.
+
+  ## Example
+
+      new_email()
+      |> assign(%{user: user})
+      |> render(:template_name)
+
+      new_email()
+      |> assign(user: user)
+      |> render(:template_name)
+  """
+  def assign(%{assigns: assigns} = email, attrs) when is_map(attrs) or is_list(attrs) do
+    %{email | assigns: Enum.into(attrs, assigns)}
+  end
+
+  @doc """
+  Sets an assign for the email. These will be available when rendering the email.
 
   ## Example
 

--- a/test/lib/bamboo/template_test.exs
+++ b/test/lib/bamboo/template_test.exs
@@ -63,6 +63,12 @@ defmodule Bamboo.TemplateTest do
       |> render(:email_with_assigns)
     end
 
+    def email_with_many_assigns(user) do
+      new_email()
+      |> assign(%{user: user})
+      |> render(:email_with_assigns)
+    end
+
     def html_email do
       new_email()
       |> render("html_email.html")
@@ -130,6 +136,11 @@ defmodule Bamboo.TemplateTest do
     email = Email.email_with_already_assigned_user(%{name: name})
     assert email.html_body =~ "<strong>#{name}</strong>"
     assert email.text_body =~ name
+
+    name = "Paul"
+    email = Email.email_with_many_assigns(%{name: name})
+    assert email.html_body =~ "<strong>#{name}</strong>"
+    assert email.text_body =~ name
   end
 
   test "render/2 renders html body if template extension is .html" do
@@ -181,6 +192,52 @@ defmodule Bamboo.TemplateTest do
   test "render/2 raises an error if no view is specified" do
     assert_raise ArgumentError, ~r/have a view set/, fn ->
       EmailNoView.no_view()
+    end
+  end
+
+  describe "assign/2" do
+    test "it accepts a map of assigns" do
+      email =
+        Bamboo.Email.new_email()
+        |> Bamboo.Template.assign(%{name: "Jules"})
+
+      assert %{name: "Jules"} = email.assigns
+    end
+
+    test "it accepts a list of assigns" do
+      email =
+        Bamboo.Email.new_email()
+        |> Bamboo.Template.assign(name: "Jules")
+
+      assert %{name: "Jules"} = email.assigns
+    end
+
+    test "it overrides any existing assigns with the same keys" do
+      email =
+        Bamboo.Email.new_email()
+        |> Bamboo.Template.assign(name: "James")
+        |> Bamboo.Template.assign(name: "Jules")
+
+      assert %{name: "Jules"} = email.assigns
+    end
+  end
+
+  describe "assign/3" do
+    test "sets given assign in list of assigns" do
+      email =
+        Bamboo.Email.new_email()
+        |> Bamboo.Template.assign(:name, "Jules")
+
+      assert %{name: "Jules"} = email.assigns
+    end
+
+    test "overrides any assigns already listed" do
+      email =
+        Bamboo.Email.new_email()
+        |> Bamboo.Template.assign(:name, "James")
+        |> Bamboo.Template.assign(:name, "Jules")
+
+      assert %{name: "Jules"} = email.assigns
     end
   end
 end


### PR DESCRIPTION
Inspired by https://github.com/thoughtbot/bamboo/pull/563

What changed?
============

We introduce `Bamboo.Template.assign/2` to sets many assigns for an email. It accepts a map or a keyword list as an argument.

We also take inspiration from [Phoenix.LiveView.assign/2][assign/2]

[assign/2]: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#assign/2