### PR TITLE
Set default timeout in test helpers to 100ms

### DIFF
--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -477,7 +477,7 @@ defmodule Bamboo.Test do
         but may incorrectly pass if an email is delivered *after* the timeout.
         """
     else
-      Keyword.get(opts, :timeout, 100)
+      get_timeout(opts)
     end
   end
 
@@ -493,5 +493,5 @@ defmodule Bamboo.Test do
   end
 
   @doc false
-  def get_timeout(opts), do: Keyword.get(opts, :timeout, 1000)
+  def get_timeout(opts), do: Keyword.get(opts, :timeout, 100)
 end


### PR DESCRIPTION
Commit aa8c458 introduced the ability to accept a timeout option in test helpers. To consolidate logic, it extracted a `get_timeout/1` function, but it incorrectly set the default value to 1000 ms. This commit corrects that by setting it to 100 ms.

We also take the opportunity to use the `get_timeout/1` helper from the `refute_timeout/1` function, thus we consolidate all fetching of the `:timeout` option to the `get_timeout/1` helper.