### PR TITLE
Better local preview for text-only emails

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -155,6 +155,7 @@
         margin: 0 0 12px 0;
         font-size: 15px;
         font-weight: 700;
+        color: #2D9EB9;
       }
 
       .email-detail-body-label + .email-detail-body-label {

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -157,6 +157,10 @@
         font-weight: 700;
       }
 
+      .email-detail-body-label + .email-detail-body-label {
+        margin-top: 30px;
+      }
+
       .email-detail-recipients,
       .email-detail-headers,
       .email-detail-attachments {
@@ -228,22 +232,30 @@
         </section>
 
         <section class="email-detail-bodies-container">
-          <h3 class="email-detail-body-label">HTML body</h3>
-          <p class="email-detail-body">
-            <script>
-            function adjustFrameHeight(iframe) {
-              var contentWindow = iframe.contentWindow;
-              var height = (contentWindow.outerHeight)
-                ? contentWindow.outerHeight
-                : contentWindow.screen.availHeight;
-              iframe.style.height = height + "px";
-            }
-            </script>
-            <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
-          </p>
+          <%= if @selected_email.html_body do %>
+            <h3 class="email-detail-body-label">HTML body</h3>
+            <p class="email-detail-body">
+              <script>
+              function adjustFrameHeight(iframe) {
+                var contentWindow = iframe.contentWindow;
+                var height = (contentWindow.outerHeight)
+                  ? contentWindow.outerHeight
+                  : contentWindow.screen.availHeight;
+                iframe.style.height = height + "px";
+              }
+              </script>
+              <iframe onload="adjustFrameHeight(this)" src="<%= "#{@base_path}/#{Bamboo.SentEmail.get_id(@selected_email)}/html" %>"></iframe>
+            </p>
+          <% else %>
+            <h3 class="email-detail-body-label">No HTML body</h3>
+          <% end %>
 
-          <h3 class="email-detail-body-label">Text Body</h3>
-          <pre class="email-detail-body"><%= Bamboo.SentEmailViewerPlug.Helper.format_text_body(@selected_email.text_body) %></pre>
+          <%= if @selected_email.text_body do %>
+            <h3 class="email-detail-body-label">Text body</h3>
+            <pre class="email-detail-body"><%= Bamboo.SentEmailViewerPlug.Helper.format_text_body(@selected_email.text_body) %></pre>
+          <% else %>
+            <h3 class="email-detail-body-label">No text body</h3>
+          <% end %>
         </section>
       </section>
     </main>


### PR DESCRIPTION
As promised in #614, this PR makes the local preview more compact for messages that have no HTML body.

Note:
There is a second commit in this PR that adds color to the headings "HTML body" and "Text body". This is not exactly related to the issue at hand and we understand that this change might not be welcome. Feel free to leave it out.