### PR TITLE
support SendGrid subscription_tracking API params

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -130,6 +130,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_bypass_list_management(email)
     |> put_google_analytics(email)
     |> put_click_tracking(email)
+    |> put_subscription_tracking(email)
     |> put_ip_pool_name(email)
     |> put_unique_args(email)
   end
@@ -367,6 +368,18 @@ defmodule Bamboo.SendGridAdapter do
   end
 
   defp put_click_tracking(body, _), do: body
+
+  defp put_subscription_tracking(body, %Email{private: %{subscription_tracking: opts}}) do
+    tracking_settings =
+      body
+      |> Map.get(:tracking_settings, %{})
+      |> Map.put(:subscription_tracking, opts)
+
+    body
+    |> Map.put(:tracking_settings, tracking_settings)
+  end
+
+  defp put_subscription_tracking(body, _), do: body
 
   defp put_attachments(body, %Email{attachments: []}), do: body
 

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -24,6 +24,7 @@ defmodule Bamboo.SendGridHelper do
   @ip_pool_name_field :ip_pool_name
   @unique_args :unique_args
   @click_tracking_enabled :click_tracking_enabled
+  @subscription_tracking :subscription_tracking
 
   @doc """
   Specify the template for SendGrid to use for the context of the substitution
@@ -64,9 +65,9 @@ defmodule Bamboo.SendGridHelper do
   end
 
   @doc """
-  Sets a list of categories for this email. 
+  Sets a list of categories for this email.
 
-  A maximum of 10 categories can be assigned to an email. Duplicate categories will 
+  A maximum of 10 categories can be assigned to an email. Duplicate categories will
   be ignored and only unique entries will be sent.
 
   ## Example
@@ -171,9 +172,9 @@ defmodule Bamboo.SendGridHelper do
 
   @doc """
   Instruct SendGrid to enable or disable Google Analytics tracking, and
-  optionally set the UTM parameters for it. 
+  optionally set the UTM parameters for it.
 
-  This is useful if you need to control UTM tracking parameters on an individual email 
+  This is useful if you need to control UTM tracking parameters on an individual email
   basis.
 
   ## Example
@@ -220,6 +221,37 @@ defmodule Bamboo.SendGridHelper do
 
   def with_click_tracking(_email, _enabled) do
     raise "expected with_click_tracking enabled parameter to be a boolean"
+  end
+
+  @doc """
+  Instruct SendGrid to enable or disable Subscription Tracking for a particular email.
+
+  Read more about SendGrid click tracking [here](https://docs.sendgrid.com/ui/account-and-settings/tracking#subscription-tracking)
+
+  ## Example
+
+      email
+      |> with_subscription_tracking(true)
+
+      email
+      |> with_subscription_tracking(true, %{html: "<p>To Unsubscribe, <% clickhere %></p>"})
+
+      email
+      |> with_subscription_tracking(false)
+  """
+  def with_subscription_tracking(email, enabled, opts \\ %{})
+
+  def with_subscription_tracking(email, enabled, opts) when is_boolean(enabled) do
+    options =
+      opts
+      |> Map.take([:html, :substitution_tag, :text])
+      |> Map.put(:enable, enabled)
+
+    Email.put_private(email, @subscription_tracking, options)
+  end
+
+  def with_subscription_tracking(_email, _enabled, _opts) do
+    raise "expected with_subscription_tracking enabled parameter to be a boolean"
   end
 
   @doc """
@@ -325,7 +357,7 @@ defmodule Bamboo.SendGridHelper do
   end
 
   @doc """
-  Set a map of unique arguments for this email. 
+  Set a map of unique arguments for this email.
 
   This will override any existing unique arguments.
 

--- a/test/lib/bamboo/adapters/send_grid_helper_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_helper_test.exs
@@ -201,6 +201,29 @@ defmodule Bamboo.SendGridHelperTest do
     end
   end
 
+  test "with_subscription_tracking/2 with enabled set false", %{email: email} do
+    email = with_subscription_tracking(email, false)
+
+    assert email.private[:subscription_tracking][:enable] == false
+  end
+
+  test "with_subscription_tracking/2 ignores invalid options", %{email: email} do
+    email =
+      with_subscription_tracking(email, true, %{
+        html: "<p>Unsubscribe <% UNSUB_URL %></p>",
+        truck: "dodge"
+      })
+
+    options = email.private[:subscription_tracking]
+    assert Map.keys(options) == [:enable, :html]
+  end
+
+  test "with_subscription_tracking/2 raises on non-boolean enabled parameter", %{email: email} do
+    assert_raise RuntimeError, fn ->
+      with_subscription_tracking(email, 1)
+    end
+  end
+
   describe "with_send_at/2" do
     test "adds the correct property for a DateTime input", %{email: email} do
       {:ok, datetime, _} = DateTime.from_iso8601("2020-01-31T15:46:00Z")


### PR DESCRIPTION
SendGrid supports customization of subscription tracking via the mail-send API call (see https://docs.sendgrid.com/api-reference/mail-send/mail-send#body).  This PR allows access to configure these options similar to the existing click_tracking configuration.