### PR TITLE
Support private custom args

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -131,7 +131,7 @@ defmodule Bamboo.SendGridAdapter do
     |> put_google_analytics(email)
     |> put_click_tracking(email)
     |> put_ip_pool_name(email)
-    |> put_unique_args(email)
+    |> put_custom_args(email)
   end
 
   defp put_from(body, %Email{from: from}) do
@@ -454,12 +454,4 @@ defmodule Bamboo.SendGridAdapter do
     do: Map.put(body, :ip_pool_name, ip_pool_name)
 
   defp put_ip_pool_name(body, _), do: body
-
-  defp put_unique_args(body, %Email{private: %{unique_args: unique_args}})
-       when is_map(unique_args) do
-    body
-    |> Map.put(:unique_args, unique_args)
-  end
-
-  defp put_unique_args(body, _), do: body
 end

--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -22,7 +22,7 @@ defmodule Bamboo.SendGridHelper do
   @allowed_google_analytics_utm_params ~w(utm_source utm_medium utm_campaign utm_term utm_content)a
   @send_at_field :sendgrid_send_at
   @ip_pool_name_field :ip_pool_name
-  @unique_args :unique_args
+  @custom_args :custom_args
   @click_tracking_enabled :click_tracking_enabled
 
   @doc """
@@ -64,9 +64,9 @@ defmodule Bamboo.SendGridHelper do
   end
 
   @doc """
-  Sets a list of categories for this email. 
+  Sets a list of categories for this email.
 
-  A maximum of 10 categories can be assigned to an email. Duplicate categories will 
+  A maximum of 10 categories can be assigned to an email. Duplicate categories will
   be ignored and only unique entries will be sent.
 
   ## Example
@@ -171,9 +171,9 @@ defmodule Bamboo.SendGridHelper do
 
   @doc """
   Instruct SendGrid to enable or disable Google Analytics tracking, and
-  optionally set the UTM parameters for it. 
+  optionally set the UTM parameters for it.
 
-  This is useful if you need to control UTM tracking parameters on an individual email 
+  This is useful if you need to control UTM tracking parameters on an individual email
   basis.
 
   ## Example
@@ -325,25 +325,25 @@ defmodule Bamboo.SendGridHelper do
   end
 
   @doc """
-  Set a map of unique arguments for this email. 
+  Set a map of custom arguments for this email.
 
-  This will override any existing unique arguments.
+  This will override any existing custom arguments.
 
   ## Example
 
       email
-      |> with_unique_args(%{new_arg_1: "new arg 1", new_arg_2: "new arg 2"})
+      |> with_custom_args(%{new_arg_1: "new arg 1", new_arg_2: "new arg 2"})
   """
-  def with_unique_args(email, unique_args) when is_map(unique_args) do
-    unique_args =
-      Map.get(email.private, @unique_args, %{})
-      |> Map.merge(unique_args)
+  def with_custom_args(email, custom_args) when is_map(custom_args) do
+    custom_args =
+      Map.get(email.private, @custom_args, %{})
+      |> Map.merge(custom_args)
 
     email
-    |> Email.put_private(@unique_args, unique_args)
+    |> Email.put_private(@custom_args, custom_args)
   end
 
-  def with_unique_args(_email, _unique_args) do
-    raise "expected a map of unique arguments"
+  def with_custom_args(_email, _custom_args) do
+    raise "expected a map of custom arguments"
   end
 end

--- a/test/lib/bamboo/adapters/send_grid_adapter_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_adapter_test.exs
@@ -660,23 +660,23 @@ defmodule Bamboo.SendGridAdapterTest do
     assert msg =~ ~r/'email' field/
   end
 
-  test "deliver/2 correctly handles with_unique_args" do
+  test "deliver/2 correctly handles with_custom_args" do
     email = new_email()
 
-    unique_args = %{
+    custom_args = %{
       new_arg1: "new arg 1",
       new_arg2: "new arg 2",
       new_arg3: "new arg 3"
     }
 
     email
-    |> Bamboo.SendGridHelper.with_unique_args(unique_args)
+    |> Bamboo.SendGridHelper.with_custom_args(custom_args)
     |> SendGridAdapter.deliver(@config)
 
     assert_receive {:fake_sendgrid, %{params: params}}
-    assert params["unique_args"]["new_arg1"] == "new arg 1"
-    assert params["unique_args"]["new_arg2"] == "new arg 2"
-    assert params["unique_args"]["new_arg3"] == "new arg 3"
+    assert params["custom_args"]["new_arg1"] == "new arg 1"
+    assert params["custom_args"]["new_arg2"] == "new arg 2"
+    assert params["custom_args"]["new_arg3"] == "new arg 3"
   end
 
   test "deliver/2 will set sandbox mode correctly" do

--- a/test/lib/bamboo/adapters/send_grid_helper_test.exs
+++ b/test/lib/bamboo/adapters/send_grid_helper_test.exs
@@ -226,27 +226,27 @@ defmodule Bamboo.SendGridHelperTest do
     assert email.private[:ip_pool_name] == @ip_pool_name
   end
 
-  test "with_unique_args/2 merges multiple maps", %{email: email} do
+  test "with_custom_args/2 merges multiple maps", %{email: email} do
     email =
       email
-      |> with_unique_args(%{new_arg_1: "new arg 1", new_arg_2: "new arg 2"})
-      |> with_unique_args(%{new_arg_3: "new arg 3"})
+      |> with_custom_args(%{new_arg_1: "new arg 1", new_arg_2: "new arg 2"})
+      |> with_custom_args(%{new_arg_3: "new arg 3"})
 
-    assert map_size(email.private[:unique_args]) == 3
+    assert map_size(email.private[:custom_args]) == 3
   end
 
-  test "with_unique_args/2 overrides duplicate entries", %{email: email} do
+  test "with_custom_args/2 overrides duplicate entries", %{email: email} do
     email =
       email
-      |> with_unique_args(%{new_arg_1: "new arg 1"})
-      |> with_unique_args(%{new_arg_1: "latest new arg 1", new_arg_2: "new arg 2"})
+      |> with_custom_args(%{new_arg_1: "new arg 1"})
+      |> with_custom_args(%{new_arg_1: "latest new arg 1", new_arg_2: "new arg 2"})
 
-    assert map_size(email.private[:unique_args]) == 2
+    assert map_size(email.private[:custom_args]) == 2
   end
 
-  test "with_unique_args/2 raises on non-map parameter", %{email: email} do
+  test "with_custom_args/2 raises on non-map parameter", %{email: email} do
     assert_raise RuntimeError, fn ->
-      email |> with_unique_args(["new arg"])
+      email |> with_custom_args(["new arg"])
     end
   end
 end


### PR DESCRIPTION
According to [sendgrid's documentation](https://docs.sendgrid.com/for-developers/tracking-events/event#unique-arguments-and-custom-arguments), sendgrid's v3 endpoint do not support unique_args:
<img width="761" alt="image" src="https://user-images.githubusercontent.com/17001577/197894649-131168d7-aa12-4eeb-a7e5-e27e839a26d0.png">

Therefore, this PR removes all code related to put/with unique_args and changes it to put/with custom_args
